### PR TITLE
Add clients list view

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -4,10 +4,11 @@
       <nav class="space-y-4">
         <router-link to="/dashboard" class="block text-gray-700 hover:text-blue-600">Início</router-link>
         <router-link to="/configuracao" class="block text-gray-700 hover:text-blue-600">Configurações</router-link>
+        <router-link to="/clientes" class="block text-gray-700 hover:text-blue-600">Clientes</router-link>
       </nav>
     </aside>
   </template>
-  
+
   <script>
   export default {
     name: 'Sidebar'

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,8 +4,8 @@ import Signup from '../views/Signup.vue'
 import Login from '../views/Login.vue'
 import Dashboard from '../views/Dashboard.vue'
 import Configuracao from '../views/Configuracao.vue'
+import ClientesList from '../views/ClientesList.vue'
 import PublicPage from '../views/PublicPage.vue'
-
 
 const routes = [
   { path: '/', name: 'Home', component: Home },
@@ -13,6 +13,7 @@ const routes = [
   { path: '/login', name: 'Login', component: Login },
   { path: '/dashboard', name: 'Dashboard', component: Dashboard },
   { path: '/configuracao', name: 'Configuracao', component: Configuracao },
+  { path: '/clientes', name: 'ClientesList', component: ClientesList },
   { path: '/:slug', name: 'PublicPage', component: PublicPage },
 ]
 

--- a/src/views/ClientesList.vue
+++ b/src/views/ClientesList.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="min-h-screen flex bg-gray-100">
+    <Sidebar />
+
+    <main class="flex-1 p-8">
+      <HeaderUser title="Clientes" />
+
+      <div>
+        <table class="min-w-full bg-white border" v-if="clientes.length">
+          <thead>
+            <tr>
+              <th class="px-4 py-2 border">Nome</th>
+              <th class="px-4 py-2 border">Email</th>
+              <th class="px-4 py-2 border">Telefone</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="cliente in clientes" :key="cliente.id">
+              <td class="px-4 py-2 border">{{ cliente.name }}</td>
+              <td class="px-4 py-2 border">{{ cliente.email }}</td>
+              <td class="px-4 py-2 border">{{ cliente.phone }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <p v-else class="text-gray-500">Nenhum cliente encontrado.</p>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script>
+import Sidebar from '../components/Sidebar.vue'
+import HeaderUser from '../components/HeaderUser.vue'
+import { supabase } from '../supabase'
+
+export default {
+  name: 'ClientesList',
+  components: { Sidebar, HeaderUser },
+  data() {
+    return {
+      clientes: []
+    }
+  },
+  async mounted() {
+    const { data, error } = await supabase
+      .from('clients')
+      .select()
+
+    if (!error) {
+      this.clientes = data || []
+    } else {
+      console.error('Erro ao carregar clientes:', error.message)
+    }
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- list clients from Supabase in a new `ClientesList` view
- link the clients page in the sidebar
- register the route in the router

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f79377848832ea89b85a3a61e1473