### PR TITLE
Update Clientes view with modal form and delete button

### DIFF
--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" @click.self="$emit('close')">
+    <div class="bg-white p-6 rounded-lg shadow-lg w-full max-w-lg">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Modal'
+}
+</script>

--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -4,29 +4,38 @@
     <main class="flex-1 p-8">
       <HeaderUser title="Clientes" />
       <section>
-        <form @submit.prevent="handleAddClient" class="space-y-6 max-w-lg">
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Nome</label>
-            <input type="text" v-model="form.name" class="w-full mt-1 px-4 py-2 border rounded-md" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">E-mail</label>
-            <input type="email" v-model="form.email" class="w-full mt-1 px-4 py-2 border rounded-md" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Telefone</label>
-            <input type="text" v-model="form.phone" class="w-full mt-1 px-4 py-2 border rounded-md" />
-          </div>
-          <div>
-            <button type="submit" class="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700">Salvar</button>
-          </div>
-        </form>
+        <button @click="openModal" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">Novo Cliente</button>
+
+        <Modal v-if="showModal" @close="closeModal">
+          <h3 class="text-lg font-semibold mb-4">Adicionar Cliente</h3>
+          <form @submit.prevent="handleAddClient" class="space-y-6">
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Nome</label>
+              <input type="text" v-model="form.name" class="w-full mt-1 px-4 py-2 border rounded-md" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">E-mail</label>
+              <input type="email" v-model="form.email" class="w-full mt-1 px-4 py-2 border rounded-md" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Telefone</label>
+              <input type="text" v-model="form.phone" class="w-full mt-1 px-4 py-2 border rounded-md" />
+            </div>
+            <div class="flex justify-end space-x-2">
+              <button type="button" @click="closeModal" class="px-4 py-2 rounded border">Cancelar</button>
+              <button type="submit" class="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700">Salvar</button>
+            </div>
+          </form>
+        </Modal>
 
         <div class="mt-8">
           <h3 class="text-lg font-medium mb-4">Clientes cadastrados</h3>
           <ul class="space-y-2">
-            <li v-for="client in clients" :key="client.id" class="p-3 bg-white shadow rounded">
-              <strong>{{ client.name }}</strong> - {{ client.email }} - {{ client.phone }}
+            <li v-for="client in clients" :key="client.id" class="p-3 bg-white shadow rounded flex justify-between items-center">
+              <span>
+                <strong>{{ client.name }}</strong> - {{ client.email }} - {{ client.phone }}
+              </span>
+              <button @click="handleDeleteClient(client.id)" class="text-red-600 hover:underline">Excluir</button>
             </li>
           </ul>
         </div>
@@ -38,14 +47,16 @@
 <script>
 import Sidebar from '../components/Sidebar.vue'
 import HeaderUser from '../components/HeaderUser.vue'
+import Modal from '../components/Modal.vue'
 import { supabase } from '../supabase'
 
 export default {
   name: 'Clientes',
-  components: { Sidebar, HeaderUser },
+  components: { Sidebar, HeaderUser, Modal },
   data() {
     return {
       userId: null,
+      showModal: false,
       form: {
         name: '',
         email: '',
@@ -55,6 +66,13 @@ export default {
     }
   },
   methods: {
+    openModal() {
+      this.showModal = true
+    },
+    closeModal() {
+      this.showModal = false
+      this.form = { name: '', email: '', phone: '' }
+    },
     async handleAddClient() {
       const { data, error } = await supabase
         .from('clients')
@@ -71,7 +89,19 @@ export default {
         alert('Erro ao salvar cliente: ' + error.message)
       } else {
         this.clients.push(data)
-        this.form = { name: '', email: '', phone: '' }
+        this.closeModal()
+      }
+    },
+    async handleDeleteClient(id) {
+      const { error } = await supabase
+        .from('clients')
+        .delete()
+        .eq('id', id)
+
+      if (error) {
+        alert('Erro ao excluir cliente: ' + error.message)
+      } else {
+        this.clients = this.clients.filter(c => c.id !== id)
       }
     }
   },


### PR DESCRIPTION
## Summary
- add basic `Modal` component
- convert client creation form to a modal
- include delete button in client list and implement deletion logic

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7af77080832ea8b5d876103ff118