### PR TITLE
Add quick client page link

### DIFF
--- a/src/views/Configuracao.vue
+++ b/src/views/Configuracao.vue
@@ -9,7 +9,15 @@
           <div>
             <label class="block text-sm font-medium text-gray-700">Nome Comercial</label>
             <input type="text" v-model="form.businessName" @input="updateSlug" class="w-full mt-1 px-4 py-2 border rounded-md">
-            <p class="text-sm text-gray-500 mt-1">Seu link público: <span class="font-mono">/agenda-zen/#/{{ slug }}</span></p>
+            <p class="text-sm text-gray-500 mt-1">
+              Seu link público:
+              <span class="font-mono">/agenda-zen/#/{{ slug }}</span>
+              <a
+                :href="'/agenda-zen/#/' + slug"
+                target="_blank"
+                class="text-blue-600 hover:underline ml-2"
+              >Abrir página do cliente</a>
+            </p>
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">Descrição do Estabelecimento</label>


### PR DESCRIPTION
## Summary
- add a button to open the public client page from Configuracao view

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f869c4dcc832eb3aa1e04f133f189