### PR TITLE
Implementar busca pública de perfis

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -1,8 +1,9 @@
 <template>
     <nav class="flex items-center justify-between px-8 py-4 bg-white shadow">
         <div class="text-xl font-bold text-blue-600">Agenda Zen</div>
-        <div>
-        <router-link to="/login" class="text-blue-600 hover:underline mr-4">Login</router-link>
+        <div class="flex items-center space-x-4">
+        <router-link to="/buscar" class="text-blue-600 hover:underline">Buscar</router-link>
+        <router-link to="/login" class="text-blue-600 hover:underline">Login</router-link>
         <router-link to="/cadastro" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">Cadastre-se</router-link>
         </div>
     </nav>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -8,6 +8,7 @@ import Clientes from '../views/Clientes.vue'
 import Agendamentos from '../views/Agendamentos.vue'
 import Servicos from '../views/Servicos.vue'
 import Usuarios from '../views/Usuarios.vue'
+import SearchProfiles from '../views/SearchProfiles.vue'
 import PublicPage from '../views/PublicPage.vue'
 
 
@@ -21,6 +22,7 @@ const routes = [
   { path: '/servicos', name: 'Servicos', component: Servicos },
   { path: '/agendamentos', name: 'Agendamentos', component: Agendamentos },
   { path: '/usuarios', name: 'Usuarios', component: Usuarios },
+  { path: '/buscar', name: 'SearchProfiles', component: SearchProfiles },
   { path: '/:slug', name: 'PublicPage', component: PublicPage },
 ]
 

--- a/src/views/SearchProfiles.vue
+++ b/src/views/SearchProfiles.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="min-h-screen bg-gradient-to-b from-white to-blue-50 py-10">
+    <div class="max-w-2xl mx-auto px-4">
+      <div class="mb-6 text-center">
+        <h1 class="text-3xl font-extrabold text-blue-700 mb-4">Buscar perfis</h1>
+        <input
+          v-model="search"
+          type="text"
+          placeholder="Digite o nome do estabelecimento"
+          class="w-full px-4 py-2 border rounded-md"
+        />
+      </div>
+      <ul class="space-y-4">
+        <li
+          v-for="profile in filteredProfiles"
+          :key="profile.id"
+          class="bg-white p-4 rounded-md shadow"
+        >
+          <h2 class="text-xl font-semibold text-blue-600">{{ profile.business_name }}</h2>
+          <p class="text-gray-700 mb-2">{{ profile.description }}</p>
+          <router-link
+            :to="'/' + profile.slug"
+            class="text-blue-600 hover:underline"
+          >
+            Ver perfil
+          </router-link>
+        </li>
+        <li
+          v-if="filteredProfiles.length === 0"
+          class="text-center text-gray-500 py-6"
+        >
+          Nenhum resultado encontrado
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script>
+import { supabase } from '../supabase'
+
+export default {
+  name: 'SearchProfiles',
+  data() {
+    return {
+      profiles: [],
+      search: ''
+    }
+  },
+  computed: {
+    filteredProfiles() {
+      const term = this.search.toLowerCase()
+      return this.profiles.filter(p =>
+        p.business_name.toLowerCase().includes(term)
+      )
+    }
+  },
+  async mounted() {
+    const { data } = await supabase
+      .from('profiles')
+      .select('id, business_name, description, slug')
+
+    if (data) {
+      this.profiles = data
+    }
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- criar nova página `SearchProfiles.vue` para busca pública de perfis
- adicionar link de busca na `Navbar`
- registrar rota `/buscar` no router

## Testing
- `npm run build` *(falhou: vite não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6840c362c21c832e82c8a45158e9e9a5