### PR TITLE
Improve appointment UI

### DIFF
--- a/supabase/schemas/003_create_appointments.sql
+++ b/supabase/schemas/003_create_appointments.sql
@@ -5,6 +5,7 @@ create table if not exists appointments (
   service_id uuid references services(id) on delete set null,
   date date not null,
   time time not null,
+  duration text,
   description text,
   created_at timestamp with time zone default now()
 );


### PR DESCRIPTION
## Summary
- allow storing appointment duration in schema
- add duration field and list appointments in a table
- auto-fill duration when selecting a service

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c6c24fc4832e99bad42564635def