### PR TITLE
Add confirmation before record deletion

### DIFF
--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -281,6 +281,11 @@ export default {
       }
     },
     async handleDeleteAppointment(id) {
+      const confirmed = confirm(
+        'Tem certeza que deseja excluir este agendamento?'
+      )
+      if (!confirmed) return
+
       const { error } = await supabase
         .from('appointments')
         .delete()

--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -136,6 +136,9 @@ export default {
       }
     },
     async handleDeleteClient(id) {
+      const confirmed = confirm('Tem certeza que deseja excluir este cliente?')
+      if (!confirmed) return
+
       const { error } = await supabase
         .from('clients')
         .delete()

--- a/src/views/Servicos.vue
+++ b/src/views/Servicos.vue
@@ -136,6 +136,9 @@ export default {
       }
     },
     async handleDeleteService(id) {
+      const confirmed = confirm('Tem certeza que deseja excluir este serviço?')
+      if (!confirmed) return
+
       const { error } = await supabase
         .from('services')
         .delete()


### PR DESCRIPTION
## Summary
- prompt users before deleting clients, appointments or services

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cb013538832eaeef0770c0e2d156