### PR TITLE
Add responsive sidebar to client screen

### DIFF
--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -1,7 +1,14 @@
 <template>
-  <div class="min-h-screen flex bg-gray-100">
-    <Sidebar />
-    <main class="flex-1 p-8 space-y-6">
+  <div class="min-h-screen flex bg-gray-100 relative">
+    <Sidebar :is-open="sidebarOpen" @close="sidebarOpen = false" />
+    <main class="flex-1 p-4 md:p-8 space-y-6">
+      <div class="md:hidden flex items-center mb-4">
+        <button @click="sidebarOpen = true" class="text-gray-600 focus:outline-none">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+          </svg>
+        </button>
+      </div>
       <HeaderUser title="Clientes" />
 
       <section class="bg-white p-6 rounded-lg shadow">
@@ -113,7 +120,8 @@ export default {
         email: '',
         phone: ''
       },
-      clients: []
+      clients: [],
+      sidebarOpen: false
     }
   },
   methods: {


### PR DESCRIPTION
## Summary
- improve Clientes view layout for small screens by adding a sidebar toggle and mobile padding

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cd79a840832e9b2fd4ae2032b4f1