### PR TITLE
Implement color and avatar on signup

### DIFF
--- a/src/views/Signup.vue
+++ b/src/views/Signup.vue
@@ -14,6 +14,15 @@
           <label class="block text-sm font-medium text-gray-700 mb-1" for="password">Senha</label>
           <input v-model="password" type="password" id="password" placeholder="********" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
         </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1" for="color">Cor do perfil</label>
+          <input v-model="color" type="color" id="color" class="w-16 h-10 border border-gray-300 rounded-md">
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1" for="avatar">Imagem do perfil</label>
+          <input type="file" id="avatar" accept="image/*" capture="user" @change="handleFileUpload">
+          <img v-if="previewUrl" :src="previewUrl" alt="Pré-visualização" class="mt-2 w-24 h-24 object-cover rounded-full">
+        </div>
         <button type="submit" class="w-full bg-blue-600 text-white font-semibold py-3 rounded-lg hover:bg-blue-700 transition duration-200">Cadastrar</button>
       </form>
       <p class="mt-6 text-center text-sm text-gray-500">
@@ -31,10 +40,31 @@ export default {
   data() {
     return {
       email: '',
-      password: ''
+      password: '',
+      color: '#000000',
+      avatarFile: null,
+      previewUrl: null
     }
   },
   methods: {
+    handleFileUpload(event) {
+      const file = event.target.files[0]
+      if (file) {
+        this.avatarFile = file
+        this.previewUrl = URL.createObjectURL(file)
+      } else {
+        this.avatarFile = null
+        this.previewUrl = null
+      }
+    },
+    toBase64(file) {
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader()
+        reader.readAsDataURL(file)
+        reader.onload = () => resolve(reader.result)
+        reader.onerror = error => reject(error)
+      })
+    },
     async handleSignup() {
       const { data, error } = await supabase.auth.signUp({
         email: this.email,
@@ -44,6 +74,17 @@ export default {
       if (error) {
         alert('Erro ao cadastrar: ' + error.message)
       } else {
+        let avatarData = null
+        if (this.avatarFile) {
+          avatarData = await this.toBase64(this.avatarFile)
+        }
+        if (data?.user) {
+          await supabase.from('profiles').insert({
+            id: data.user.id,
+            color: this.color,
+            avatar_url: avatarData
+          })
+        }
         alert('Cadastro realizado! Verifique seu e-mail para ativar a conta.')
       }
     }

--- a/supabase/schemas/001_create_profiles.sql
+++ b/supabase/schemas/001_create_profiles.sql
@@ -8,10 +8,12 @@ create table if not exists profiles (
   address text,
   instagram text,
   facebook text,
-  youtube text,
-  x text,
-  created_at timestamp with time zone default now()
-);
+    youtube text,
+    x text,
+    color text,
+    avatar_url text,
+    created_at timestamp with time zone default now()
+  );
 
 alter table profiles enable row level security;
 


### PR DESCRIPTION
## Summary
- add `color` and `avatar_url` to profile schema
- allow users to pick a profile color
- allow users to capture an avatar image when signing up
- store new fields in `profiles` table during sign up

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cc7c5040832e818d8293479fa9c4