### PR TITLE
Add weekly appointments chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.49.8",
     "vue": "^3.0.0",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "chart.js": "^4.4.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.0.0",


### PR DESCRIPTION
## Summary
- show a bar chart on Dashboard
- compute appointments per weekday
- update package.json with chart.js dependency

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cf18cda0832eaef117081f1bd44e