### PR TITLE
Add profile image upload

### DIFF
--- a/src/views/Configuracao.vue
+++ b/src/views/Configuracao.vue
@@ -41,28 +41,35 @@
               <input type="text" v-model="form.address" class="w-full mt-1 px-4 py-2 border rounded-md">
             </div>
           </div>
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Instagram</label>
-              <input type="text" v-model="form.instagram" class="w-full mt-1 px-4 py-2 border rounded-md">
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Facebook</label>
-              <input type="text" v-model="form.facebook" class="w-full mt-1 px-4 py-2 border rounded-md">
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">YouTube</label>
-              <input type="text" v-model="form.youtube" class="w-full mt-1 px-4 py-2 border rounded-md">
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">X (Twitter)</label>
-              <input type="text" v-model="form.x" class="w-full mt-1 px-4 py-2 border rounded-md">
-            </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Instagram</label>
+            <input type="text" v-model="form.instagram" class="w-full mt-1 px-4 py-2 border rounded-md">
           </div>
           <div>
-            <button type="submit" class="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700">Salvar</button>
+            <label class="block text-sm font-medium text-gray-700">Facebook</label>
+            <input type="text" v-model="form.facebook" class="w-full mt-1 px-4 py-2 border rounded-md">
           </div>
-        </form>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">YouTube</label>
+            <input type="text" v-model="form.youtube" class="w-full mt-1 px-4 py-2 border rounded-md">
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">X (Twitter)</label>
+            <input type="text" v-model="form.x" class="w-full mt-1 px-4 py-2 border rounded-md">
+          </div>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700">Imagem do Estabelecimento</label>
+          <input type="file" accept="image/*" @change="handleImageUpload" class="mt-1" />
+          <div v-if="form.imageUrl" class="mt-2">
+            <img :src="form.imageUrl" alt="Imagem do estabelecimento" class="h-24 rounded-md" />
+          </div>
+        </div>
+        <div>
+          <button type="submit" class="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700">Salvar</button>
+        </div>
+      </form>
       </main>
     </div>
   </template>
@@ -90,7 +97,8 @@
           instagram: '',
           facebook: '',
           youtube: '',
-          x: ''
+          x: '',
+          imageUrl: ''
         }
       }
     },
@@ -116,7 +124,8 @@
           instagram: this.form.instagram,
           facebook: this.form.facebook,
           youtube: this.form.youtube,
-          x: this.form.x
+          x: this.form.x,
+          image_url: this.form.imageUrl
         }
         const { error } = await supabase
           .from('profiles')
@@ -127,6 +136,24 @@
         } else {
           alert('Dados salvos com sucesso!')
         }
+      }
+      async handleImageUpload(event) {
+        const file = event.target.files[0]
+        if (!file) return
+        const fileExt = file.name.split('.').pop()
+        const fileName = `${this.userId}.${fileExt}`
+        const { error } = await supabase
+          .storage
+          .from('profile-images')
+          .upload(fileName, file, { upsert: true })
+        if (error) {
+          alert('Erro ao enviar imagem: ' + error.message)
+          return
+        }
+        const {
+          data: { publicUrl }
+        } = supabase.storage.from('profile-images').getPublicUrl(fileName)
+        this.form.imageUrl = publicUrl
       }
     },
     async mounted() {
@@ -154,7 +181,8 @@
           instagram: data.instagram || '',
           facebook: data.facebook || '',
           youtube: data.youtube || '',
-          x: data.x || ''
+          x: data.x || '',
+          imageUrl: data.image_url || ''
         }
         this.updateSlug()
       }

--- a/src/views/PublicPage.vue
+++ b/src/views/PublicPage.vue
@@ -3,7 +3,7 @@
     <section v-if="profile" class="flex-1">
       <div class="bg-blue-600 text-white py-12">
         <div class="max-w-5xl mx-auto px-4 text-center space-y-4">
-          <img src="/hero-illustration.png" alt="Banner" class="w-32 h-32 mx-auto rounded-full shadow-lg" />
+          <img :src="profile.image_url || '/hero-illustration.png'" alt="Banner" class="w-32 h-32 mx-auto rounded-full shadow-lg" />
           <h1 class="text-4xl font-bold">{{ profile.business_name }}</h1>
           <p class="text-lg">{{ profile.description }}</p>
         </div>

--- a/supabase/schemas/001_create_profiles.sql
+++ b/supabase/schemas/001_create_profiles.sql
@@ -10,6 +10,7 @@ create table if not exists profiles (
   facebook text,
   youtube text,
   x text,
+  image_url text,
   created_at timestamp with time zone default now()
 );
 
@@ -20,3 +21,4 @@ create policy "Users can manage own profile"
   using (auth.uid() = id);
 
 alter table profiles add column if not exists slug text;
+alter table profiles add column if not exists image_url text;


### PR DESCRIPTION
## Summary
- add image column to profile schema
- allow profile image upload in Configuracao page
- show uploaded image on PublicPage

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cfb99ee4832e8e77fa770bbdd6ff