### PR TITLE
Fix RLS for profile image uploads

### DIFF
--- a/supabase/schemas/005_create_storage_policy.sql
+++ b/supabase/schemas/005_create_storage_policy.sql
@@ -1,0 +1,12 @@
+CREATE POLICY "Anyone can upload profile images" ON storage.objects
+FOR INSERT WITH CHECK (
+  bucket_id = 'profile-images'
+);
+
+CREATE POLICY "Anyone can read profile images" ON storage.objects
+FOR SELECT USING (
+  bucket_id = 'profile-images'
+);
+
+-- Ensure RLS is enabled for storage.objects
+ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- allow inserting and reading files from profile-images bucket

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840d3b78640832eaf910424229cdb20