### PR TITLE
Add pricing page

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -3,6 +3,7 @@
         <div class="text-xl font-bold text-blue-600">Agenda Zen</div>
         <div class="flex items-center space-x-4">
         <router-link to="/buscar" class="text-blue-600 hover:underline">Buscar</router-link>
+        <router-link to="/planos" class="text-blue-600 hover:underline">Planos</router-link>
         <router-link to="/login" class="text-blue-600 hover:underline">Login</router-link>
         <router-link to="/cadastro" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">Cadastre-se</router-link>
         </div>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -10,6 +10,7 @@ import Servicos from '../views/Servicos.vue'
 import Usuarios from '../views/Usuarios.vue'
 import SearchProfiles from '../views/SearchProfiles.vue'
 import PublicPage from '../views/PublicPage.vue'
+import Planos from '../views/Planos.vue'
 
 
 const routes = [
@@ -23,6 +24,7 @@ const routes = [
   { path: '/agendamentos', name: 'Agendamentos', component: Agendamentos },
   { path: '/usuarios', name: 'Usuarios', component: Usuarios },
   { path: '/buscar', name: 'SearchProfiles', component: SearchProfiles },
+  { path: '/planos', name: 'Planos', component: Planos },
   { path: '/:slug', name: 'PublicPage', component: PublicPage },
 ]
 

--- a/src/views/Planos.vue
+++ b/src/views/Planos.vue
@@ -1,0 +1,60 @@
+<template>
+  <Navbar />
+  <section class="max-w-5xl mx-auto px-4 py-16">
+    <h1 class="text-3xl font-bold text-center mb-8">Conheça nossos planos</h1>
+    <div class="overflow-x-auto">
+      <table class="min-w-full bg-white border border-gray-200 rounded-lg">
+        <thead>
+          <tr class="bg-gray-50 text-gray-700">
+            <th class="px-4 py-2 text-left">Recursos</th>
+            <th class="px-4 py-2">Grátis</th>
+            <th class="px-4 py-2">Básico</th>
+            <th class="px-4 py-2">Plus</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="border-t px-4 py-2 text-gray-600">Agendamentos online</td>
+            <td class="border-t px-4 py-2 text-center">✓</td>
+            <td class="border-t px-4 py-2 text-center">✓</td>
+            <td class="border-t px-4 py-2 text-center">✓</td>
+          </tr>
+          <tr class="bg-gray-50">
+            <td class="border-t px-4 py-2 text-gray-600">Lembretes automáticos</td>
+            <td class="border-t px-4 py-2 text-center">-</td>
+            <td class="border-t px-4 py-2 text-center">✓</td>
+            <td class="border-t px-4 py-2 text-center">✓</td>
+          </tr>
+          <tr>
+            <td class="border-t px-4 py-2 text-gray-600">Pagamentos via Pix</td>
+            <td class="border-t px-4 py-2 text-center">-</td>
+            <td class="border-t px-4 py-2 text-center">✓</td>
+            <td class="border-t px-4 py-2 text-center">✓</td>
+          </tr>
+          <tr class="bg-gray-50">
+            <td class="border-t px-4 py-2 text-gray-600">Suporte prioritário</td>
+            <td class="border-t px-4 py-2 text-center">-</td>
+            <td class="border-t px-4 py-2 text-center">-</td>
+            <td class="border-t px-4 py-2 text-center">✓</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="text-center mt-8">
+      <router-link to="/cadastro" class="bg-blue-600 text-white px-6 py-3 rounded hover:bg-blue-700">
+        Contratar plano
+      </router-link>
+    </div>
+  </section>
+  <Footer />
+</template>
+
+<script>
+import Navbar from '../components/Navbar.vue'
+import Footer from '../components/Footer.vue'
+
+export default {
+  name: 'Planos',
+  components: { Navbar, Footer }
+}
+</script>


### PR DESCRIPTION
## Summary
- add `Planos.vue` to present plan comparison with a signup button
- register the new page in the router
- link the pricing page from the Navbar

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68424d130034832e80d1125926da8bdd