### PR TITLE
Implement basic user list

### DIFF
--- a/src/views/Usuarios.vue
+++ b/src/views/Usuarios.vue
@@ -1,7 +1,14 @@
 <template>
-  <div class="min-h-screen flex bg-gray-100">
-    <Sidebar />
-    <main class="flex-1 p-8 space-y-6">
+  <div class="min-h-screen flex bg-gray-100 relative">
+    <Sidebar :is-open="sidebarOpen" @close="sidebarOpen = false" />
+    <main class="flex-1 p-4 md:p-8 space-y-6">
+      <div class="md:hidden flex items-center mb-4">
+        <button @click="sidebarOpen = true" class="text-gray-600 focus:outline-none">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+          </svg>
+        </button>
+      </div>
       <HeaderUser title="Usuários" />
       <section class="bg-white p-6 rounded-lg shadow">
         <h3 class="text-lg font-medium mb-4">Cadastrar novo usuário</h3>
@@ -20,6 +27,37 @@
         </form>
         <p v-if="successMessage" class="text-green-600 mt-4">{{ successMessage }}</p>
         <p v-if="errorMessage" class="text-red-600 mt-4">{{ errorMessage }}</p>
+      </section>
+
+      <section class="bg-white p-6 rounded-lg shadow">
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-lg font-medium">Usuários cadastrados</h3>
+          <input
+            v-model="search"
+            type="text"
+            placeholder="Buscar..."
+            class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div class="overflow-x-auto">
+          <table class="min-w-full text-left">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="px-4 py-2 font-medium text-gray-700">ID</th>
+                <th class="px-4 py-2 font-medium text-gray-700">E-mail</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="u in filteredUsers" :key="u.id" class="border-b last:border-b-0">
+                <td class="px-4 py-2">{{ u.id }}</td>
+                <td class="px-4 py-2">{{ u.email }}</td>
+              </tr>
+              <tr v-if="filteredUsers.length === 0">
+                <td colspan="2" class="px-4 py-6 text-center text-gray-500">Nenhum usuário encontrado</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </section>
     </main>
   </div>
@@ -41,7 +79,10 @@ export default {
       },
       userId: null,
       successMessage: '',
-      errorMessage: ''
+      errorMessage: '',
+      users: [],
+      search: '',
+      sidebarOpen: false
     }
   },
   methods: {
@@ -92,7 +133,34 @@ export default {
         }
         this.successMessage = 'Usuário cadastrado! Verifique o e-mail para ativar a conta.'
         this.form = { email: '', password: '' }
+        await this.fetchUsers()
       }
+    },
+    async fetchUsers() {
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('slug')
+        .eq('id', this.userId)
+        .single()
+
+      if (profile) {
+        const { data } = await supabase
+          .from('profiles')
+          .select('id, email')
+          .eq('slug', profile.slug)
+
+        this.users = data || []
+      }
+    }
+  },
+  computed: {
+    filteredUsers() {
+      const term = this.search.toLowerCase()
+      return this.users.filter(
+        u =>
+          u.id.toLowerCase().includes(term) ||
+          (u.email || '').toLowerCase().includes(term)
+      )
     }
   },
   async mounted() {
@@ -102,6 +170,7 @@ export default {
       return
     }
     this.userId = user.id
+    await this.fetchUsers()
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- list registered users on the "Usuários" page
- fetch users that share the same slug as the logged profile
- add filtering capability and responsive sidebar to match other admin pages

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435bcfdc08832e9fc6d9bc4df338bd