### PR TITLE
Add area de atuacao field

### DIFF
--- a/src/views/Configuracao.vue
+++ b/src/views/Configuracao.vue
@@ -30,6 +30,21 @@
             <label class="block text-sm font-medium text-gray-700">Descrição do Estabelecimento</label>
             <textarea v-model="form.description" class="w-full mt-1 px-4 py-2 border rounded-md"></textarea>
           </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Área de Atuação</label>
+            <select v-model="form.areaAtuacao" class="w-full mt-1 px-4 py-2 border rounded-md">
+              <option disabled value="">Selecione</option>
+              <option>Psicologia</option>
+              <option>Terapias Gerais</option>
+              <option>Psicopedagogia</option>
+              <option>Medicina</option>
+              <option>Coaching</option>
+              <option>Fonoaudiologia</option>
+              <option>Fisioterapia</option>
+              <option>Nutrição</option>
+              <option>Terapia Ocupacional</option>
+            </select>
+          </div>
           <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
               <label class="block text-sm font-medium text-gray-700">Telefone de Contato</label>
@@ -98,6 +113,7 @@
         form: {
           businessName: '',
           description: '',
+          areaAtuacao: '',
           phone: '',
           whatsapp: '',
           email: '',
@@ -125,6 +141,7 @@
           business_name: this.form.businessName,
           slug: this.slug,
           description: this.form.description,
+          area_atuacao: this.form.areaAtuacao,
           phone: this.form.phone,
           whatsapp: this.form.whatsapp,
           email: this.form.email,
@@ -182,6 +199,7 @@
         this.form = {
           businessName: data.business_name || '',
           description: data.description || '',
+          areaAtuacao: data.area_atuacao || '',
           phone: data.phone || '',
           whatsapp: data.whatsapp || '',
           email: data.email || '',

--- a/src/views/PublicPage.vue
+++ b/src/views/PublicPage.vue
@@ -5,6 +5,7 @@
         <div class="max-w-5xl mx-auto px-4 text-center space-y-4">
           <img :src="profile.image_url || '/hero-illustration.png'" alt="Banner" class="w-32 h-32 mx-auto rounded-full shadow-lg" />
           <h1 class="text-4xl font-bold">{{ profile.business_name }}</h1>
+          <p v-if="profile.area_atuacao" class="text-sm">{{ profile.area_atuacao }}</p>
           <p class="text-lg">{{ profile.description }}</p>
         </div>
       </div>

--- a/src/views/SearchProfiles.vue
+++ b/src/views/SearchProfiles.vue
@@ -17,6 +17,7 @@
           class="bg-white p-4 rounded-md shadow"
         >
           <h2 class="text-xl font-semibold text-blue-600">{{ profile.business_name }}</h2>
+          <p v-if="profile.area_atuacao" class="text-sm text-gray-500">{{ profile.area_atuacao }}</p>
           <p class="text-gray-700 mb-2">{{ profile.description }}</p>
           <router-link
             :to="'/' + profile.slug"
@@ -58,7 +59,7 @@ export default {
   async mounted() {
     const { data } = await supabase
       .from('profiles')
-      .select('id, business_name, description, slug')
+      .select('id, business_name, description, slug, area_atuacao')
 
     if (data) {
       this.profiles = data

--- a/supabase/schemas/001_create_profiles.sql
+++ b/supabase/schemas/001_create_profiles.sql
@@ -2,6 +2,7 @@ create table if not exists profiles (
   id uuid primary key references auth.users(id) on delete cascade,
   business_name text,
   description text,
+  area_atuacao text,
   phone text,
   whatsapp text,
   email text,
@@ -22,3 +23,4 @@ create policy "Users can manage own profile"
 
 alter table profiles add column if not exists slug text;
 alter table profiles add column if not exists image_url text;
+alter table profiles add column if not exists area_atuacao text;


### PR DESCRIPTION
## Summary
- add `area_atuacao` column to profiles schema
- allow editing `Área de Atuação` in Configurações
- show area of expertise on public profile and search list

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684363262270832eaabeab0604098096