### PR TITLE
Add schedule submenu

### DIFF
--- a/supabase/schemas/008_add_schedule_to_profiles.sql
+++ b/supabase/schemas/008_add_schedule_to_profiles.sql
@@ -1,0 +1,3 @@
+alter table profiles add column if not exists start_time time;
+alter table profiles add column if not exists end_time time;
+alter table profiles add column if not exists week_days text;


### PR DESCRIPTION
## Summary
- add "Perfil/Agenda" submenu on Configuracao page
- support saving agenda configuration
- add migration for agenda fields

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684366b89edc832e84fc225545dd78ac