### PR TITLE
Fix week navigation in week view

### DIFF
--- a/src/components/WeekView.vue
+++ b/src/components/WeekView.vue
@@ -71,10 +71,14 @@ export default {
         .sort((a, b) => a.time.localeCompare(b.time))
     },
     prevWeek() {
-      this.weekStart.setDate(this.weekStart.getDate() - 7)
+      const d = new Date(this.weekStart)
+      d.setDate(d.getDate() - 7)
+      this.weekStart = d
     },
     nextWeek() {
-      this.weekStart.setDate(this.weekStart.getDate() + 7)
+      const d = new Date(this.weekStart)
+      d.setDate(d.getDate() + 7)
+      this.weekStart = d
     }
   }
 }


### PR DESCRIPTION
## Summary
- fix week navigation not updating due to mutated Date object

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684367610a24832ea03a7639fee32819