### PR TITLE
Add nav/footer to login, signup and search pages

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,4 +1,5 @@
 <template>
+    <Navbar />
     <section class="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-100 to-blue-100 px-4">
       <div class="bg-white p-10 rounded-2xl shadow-xl w-full max-w-lg">
         <div class="mb-8 text-center">
@@ -22,14 +23,18 @@
         </p>
       </div>
     </section>
-  </template>
-  
-  <script>
-  import { supabase } from '../supabase'
-  
-  export default {
-    name: 'Login',
-    data() {
+    <Footer />
+</template>
+
+<script>
+import Navbar from '../components/Navbar.vue'
+import Footer from '../components/Footer.vue'
+import { supabase } from '../supabase'
+
+export default {
+  name: 'Login',
+  components: { Navbar, Footer },
+  data() {
       return {
         email: '',
         password: ''

--- a/src/views/SearchProfiles.vue
+++ b/src/views/SearchProfiles.vue
@@ -1,4 +1,5 @@
 <template>
+  <Navbar />
   <div class="min-h-screen bg-gradient-to-b from-white to-blue-50 py-10">
     <div class="max-w-2xl mx-auto px-4">
       <div class="mb-6 text-center">
@@ -35,13 +36,17 @@
       </ul>
     </div>
   </div>
+  <Footer />
 </template>
 
 <script>
+import Navbar from '../components/Navbar.vue'
+import Footer from '../components/Footer.vue'
 import { supabase } from '../supabase'
 
 export default {
   name: 'SearchProfiles',
+  components: { Navbar, Footer },
   data() {
     return {
       profiles: [],

--- a/src/views/Signup.vue
+++ b/src/views/Signup.vue
@@ -1,4 +1,5 @@
 <template>
+  <Navbar />
   <section class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-blue-100 px-4">
     <div class="bg-white p-10 rounded-2xl shadow-xl w-full max-w-lg">
       <div class="mb-8 text-center">
@@ -21,13 +22,17 @@
       </p>
     </div>
   </section>
+  <Footer />
 </template>
 
 <script>
+import Navbar from '../components/Navbar.vue'
+import Footer from '../components/Footer.vue'
 import { supabase } from '../supabase'
 
 export default {
   name: 'Signup',
+  components: { Navbar, Footer },
   data() {
     return {
       email: '',


### PR DESCRIPTION
## Summary
- show Navbar and Footer on `Login.vue`, `Signup.vue`, and `SearchProfiles.vue`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437b9e5978832ebe99d634f068d10c