### PR TITLE
Implement pagination for clients, services and rooms

### DIFF
--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -42,7 +42,7 @@
             </thead>
             <tbody>
               <tr
-                v-for="client in filteredClients"
+                v-for="client in paginatedClients"
                 :key="client.id"
                 class="border-b last:border-b-0"
               >
@@ -71,9 +71,26 @@
                   Nenhum cliente encontrado
                 </td>
               </tr>
-            </tbody>
-          </table>
+          </tbody>
+        </table>
+        <div class="mt-4 flex justify-between items-center">
+          <button
+            class="px-3 py-1 border rounded"
+            @click="prevPage"
+            :disabled="page === 1"
+          >
+            Anterior
+          </button>
+          <span class="text-sm">Página {{ page }} de {{ totalPages }}</span>
+          <button
+            class="px-3 py-1 border rounded"
+            @click="nextPage"
+            :disabled="page === totalPages"
+          >
+            Próxima
+          </button>
         </div>
+      </div>
       </section>
 
       <Modal v-if="showModal" @close="closeModal">
@@ -121,7 +138,9 @@ export default {
         phone: ''
       },
       clients: [],
-      sidebarOpen: true
+      sidebarOpen: true,
+      page: 1,
+      pageSize: 10
     }
   },
   methods: {
@@ -172,6 +191,12 @@ export default {
       } else {
         this.clients = this.clients.filter(c => c.id !== id)
       }
+    },
+    nextPage() {
+      if (this.page < this.totalPages) this.page++
+    },
+    prevPage() {
+      if (this.page > 1) this.page--
     }
   },
   computed: {
@@ -183,6 +208,18 @@ export default {
           c.email.toLowerCase().includes(term) ||
           c.phone.toLowerCase().includes(term)
       )
+    },
+    paginatedClients() {
+      const start = (this.page - 1) * this.pageSize
+      return this.filteredClients.slice(start, start + this.pageSize)
+    },
+    totalPages() {
+      return Math.max(1, Math.ceil(this.filteredClients.length / this.pageSize))
+    }
+  },
+  watch: {
+    search() {
+      this.page = 1
     }
   },
   async mounted() {

--- a/src/views/Salas.vue
+++ b/src/views/Salas.vue
@@ -40,7 +40,7 @@
             </thead>
             <tbody>
               <tr
-                v-for="room in filteredRooms"
+                v-for="room in paginatedRooms"
                 :key="room.id"
                 class="border-b last:border-b-0"
               >
@@ -61,6 +61,23 @@
               </tr>
             </tbody>
           </table>
+          <div class="mt-4 flex justify-between items-center">
+            <button
+              class="px-3 py-1 border rounded"
+              @click="prevPage"
+              :disabled="page === 1"
+            >
+              Anterior
+            </button>
+            <span class="text-sm">Página {{ page }} de {{ totalPages }}</span>
+            <button
+              class="px-3 py-1 border rounded"
+              @click="nextPage"
+              :disabled="page === totalPages"
+            >
+              Próxima
+            </button>
+          </div>
         </div>
       </section>
 
@@ -99,7 +116,9 @@ export default {
         name: ''
       },
       rooms: [],
-      sidebarOpen: true
+      sidebarOpen: true,
+      page: 1,
+      pageSize: 10
     }
   },
   methods: {
@@ -141,12 +160,30 @@ export default {
       } else {
         this.rooms = this.rooms.filter(r => r.id !== id)
       }
+    },
+    nextPage() {
+      if (this.page < this.totalPages) this.page++
+    },
+    prevPage() {
+      if (this.page > 1) this.page--
     }
   },
   computed: {
     filteredRooms() {
       const term = this.search.toLowerCase()
       return this.rooms.filter(r => r.name.toLowerCase().includes(term))
+    },
+    paginatedRooms() {
+      const start = (this.page - 1) * this.pageSize
+      return this.filteredRooms.slice(start, start + this.pageSize)
+    },
+    totalPages() {
+      return Math.max(1, Math.ceil(this.filteredRooms.length / this.pageSize))
+    }
+  },
+  watch: {
+    search() {
+      this.page = 1
     }
   },
   async mounted() {

--- a/src/views/Servicos.vue
+++ b/src/views/Servicos.vue
@@ -42,7 +42,7 @@
             </thead>
             <tbody>
               <tr
-                v-for="service in filteredServices"
+                v-for="service in paginatedServices"
                 :key="service.id"
                 class="border-b last:border-b-0"
               >
@@ -71,6 +71,23 @@
               </tr>
             </tbody>
           </table>
+          <div class="mt-4 flex justify-between items-center">
+            <button
+              class="px-3 py-1 border rounded"
+              @click="prevPage"
+              :disabled="page === 1"
+            >
+              Anterior
+            </button>
+            <span class="text-sm">Página {{ page }} de {{ totalPages }}</span>
+            <button
+              class="px-3 py-1 border rounded"
+              @click="nextPage"
+              :disabled="page === totalPages"
+            >
+              Próxima
+            </button>
+          </div>
         </div>
       </section>
 
@@ -120,7 +137,9 @@ export default {
         description: '',
         duration: ''
       },
-      services: []
+      services: [],
+      page: 1,
+      pageSize: 10
     }
   },
   methods: {
@@ -195,6 +214,12 @@ export default {
       } else {
         this.services = this.services.filter(s => s.id !== id)
       }
+    },
+    nextPage() {
+      if (this.page < this.totalPages) this.page++
+    },
+    prevPage() {
+      if (this.page > 1) this.page--
     }
   },
   computed: {
@@ -206,6 +231,18 @@ export default {
           (s.description || '').toLowerCase().includes(term) ||
           (s.duration || '').toLowerCase().includes(term)
       )
+    },
+    paginatedServices() {
+      const start = (this.page - 1) * this.pageSize
+      return this.filteredServices.slice(start, start + this.pageSize)
+    },
+    totalPages() {
+      return Math.max(1, Math.ceil(this.filteredServices.length / this.pageSize))
+    }
+  },
+  watch: {
+    search() {
+      this.page = 1
     }
   },
   async mounted() {


### PR DESCRIPTION
## Summary
- add pagination controls for Clientes view
- add pagination controls for Servicos view
- add pagination controls for Salas view

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437e1af57c832eb186d031dad07662