### PR TITLE
Fix GitHub Pages domain removal

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,3 +29,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+          cname: www.agendazen.com.br


### PR DESCRIPTION
## Summary
- ensure the custom domain is preserved when deploying

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843818092f0832eb9860129b86672be