### PR TITLE
Add cookie consent banner

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,13 @@
 <template>
   <router-view />
+  <CookieBanner />
 </template>
 
 <script>
+import CookieBanner from './components/CookieBanner.vue'
+
 export default {
-  name: 'App'
+  name: 'App',
+  components: { CookieBanner }
 }
 </script>

--- a/src/components/CookieBanner.vue
+++ b/src/components/CookieBanner.vue
@@ -1,0 +1,38 @@
+<template>
+  <div
+    v-if="!consentGiven"
+    class="fixed bottom-0 left-0 right-0 bg-gray-800 text-white p-4 text-center z-50"
+  >
+    <p class="mb-2">
+      Utilizamos cookies para melhorar sua experiência. Ao continuar, você
+      concorda com nossa
+      <a href="#" class="underline">política de privacidade</a>.
+    </p>
+    <button
+      @click="acceptCookies"
+      class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+    >
+      Aceitar
+    </button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'CookieBanner',
+  data() {
+    return {
+      consentGiven: false
+    }
+  },
+  mounted() {
+    this.consentGiven = localStorage.getItem('cookieConsent') === 'true'
+  },
+  methods: {
+    acceptCookies() {
+      this.consentGiven = true
+      localStorage.setItem('cookieConsent', 'true')
+    }
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- add `CookieBanner.vue` component with privacy notice
- inject `CookieBanner` in `App.vue`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439e565330832e973957260a00b3c6