### PR TITLE
Add Minha Assinatura screen

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -79,6 +79,13 @@
           </svg>
           <span>Usuários</span>
         </router-link>
+        <router-link to="/minha-assinatura" class="flex items-center text-gray-700 hover:text-blue-600">
+          <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <rect x="3" y="4" width="18" height="16" rx="2" ry="2" stroke-width="2" />
+            <line x1="3" y1="9" x2="21" y2="9" stroke-width="2" />
+          </svg>
+          <span>Minha Assinatura</span>
+        </router-link>
       </nav>
     </aside>
   </div>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -15,6 +15,7 @@ import Salas from '../views/Salas.vue'
 import Comprovantes from '../views/Comprovantes.vue'
 import Templates from '../views/Templates.vue'
 import Contato from '../views/Contato.vue'
+import MinhaAssinatura from '../views/MinhaAssinatura.vue'
 
 
 const routes = [
@@ -30,6 +31,7 @@ const routes = [
   { path: '/comprovantes', name: 'Comprovantes', component: Comprovantes },
   { path: '/templates', name: 'Templates', component: Templates },
   { path: '/usuarios', name: 'Usuarios', component: Usuarios },
+  { path: '/minha-assinatura', name: 'MinhaAssinatura', component: MinhaAssinatura },
   { path: '/buscar', name: 'SearchProfiles', component: SearchProfiles },
   { path: '/planos', name: 'Planos', component: Planos },
   { path: '/contato', name: 'Contato', component: Contato },

--- a/src/views/MinhaAssinatura.vue
+++ b/src/views/MinhaAssinatura.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="min-h-screen flex bg-gray-100 relative">
+    <Sidebar :is-open="sidebarOpen" @close="sidebarOpen = false" />
+    <main class="flex-1 p-4 md:p-8 space-y-6">
+      <div v-if="!sidebarOpen" class="flex items-center mb-4">
+        <button @click="sidebarOpen = true" class="text-gray-600 focus:outline-none">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+      <HeaderUser title="Minha Assinatura" />
+
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div class="bg-white p-6 rounded-lg shadow space-y-4">
+          <h3 class="text-xl font-semibold text-center">Básico</h3>
+          <ul class="space-y-2">
+            <li class="flex items-start"><span class="mr-2">✓</span>Cadastro de até 5 pacientes</li>
+            <li class="flex items-start"><span class="mr-2">✓</span>Lembretes por e-mail</li>
+          </ul>
+          <button class="mt-4 bg-blue-600 text-white px-4 py-2 rounded w-full hover:bg-blue-700">Escolher</button>
+        </div>
+        <div class="bg-white p-6 rounded-lg shadow space-y-4">
+          <h3 class="text-xl font-semibold text-center">Plus</h3>
+          <ul class="space-y-2">
+            <li class="flex items-start"><span class="mr-2">✓</span>Cadastro de pacientes ilimitado</li>
+            <li class="flex items-start"><span class="mr-2">✓</span>Lembretes por e-mail</li>
+            <li class="flex items-start"><span class="mr-2">✓</span>Lembretes via WhatsApp</li>
+            <li class="flex items-start"><span class="mr-2">✓</span>Customização de domínio da página pública</li>
+            <li class="flex items-start"><span class="mr-2">✓</span>Página pública sem banner do Agenda Zen</li>
+            <li class="flex items-start"><span class="mr-2">✓</span>Geração de recibos de atendimentos</li>
+            <li class="flex items-start"><span class="mr-2">✓</span>Envio de recibos por e-mail automático</li>
+          </ul>
+          <button class="mt-4 bg-blue-600 text-white px-4 py-2 rounded w-full hover:bg-blue-700">Escolher</button>
+        </div>
+      </section>
+    </main>
+  </div>
+</template>
+
+<script>
+import Sidebar from '../components/Sidebar.vue'
+import HeaderUser from '../components/HeaderUser.vue'
+
+export default {
+  name: 'MinhaAssinatura',
+  components: { Sidebar, HeaderUser },
+  data() {
+    return {
+      sidebarOpen: true
+    }
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- add a view so users can choose between Básico and Plus plans
- route `/minha-assinatura`
- navigation link in the sidebar

## Testing
- `npx vite build` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843a3883b38832eb6ee21e9ad07a63f