### PR TITLE
Organize sidebar menu groups

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -18,74 +18,82 @@
         </svg>
       </button>
       <h2 class="text-2xl font-bold text-blue-600 mb-6">Agenda Zen</h2>
-      <nav class="space-y-4 mt-8">
-        <router-link to="/dashboard" class="flex items-center text-gray-700 hover:text-blue-600">
-          <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l9-9 9 9M4 10v10a1 1 0 001 1h3m10-11v10a1 1 0 01-1 1h-3m-6 0h6" />
-          </svg>
-          <span>Início</span>
-        </router-link>
-        <router-link to="/agendamentos" class="flex items-center text-gray-700 hover:text-blue-600">
-          <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <rect x="3" y="4" width="18" height="18" rx="2" ry="2" stroke-width="2"/>
-            <line x1="16" y1="2" x2="16" y2="6" stroke-width="2"/>
-            <line x1="8" y1="2" x2="8" y2="6" stroke-width="2"/>
-            <line x1="3" y1="10" x2="21" y2="10" stroke-width="2"/>
-          </svg>
-          <span>Agendamentos</span>
-        </router-link>
-        <router-link to="/clientes" class="flex items-center text-gray-700 hover:text-blue-600">
-          <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <circle cx="12" cy="7" r="4" stroke-width="2" />
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 21v-2a6 6 0 0112 0v2" />
-          </svg>
-          <span>Clientes</span>
-        </router-link>
-        <router-link to="/servicos" class="flex items-center text-gray-700 hover:text-blue-600">
-          <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <rect x="2" y="7" width="20" height="14" rx="2" ry="2" stroke-width="2" />
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V5a4 4 0 018 0v2" />
-          </svg>
-          <span>Serviços</span>
-        </router-link>
-        <router-link to="/salas" class="flex items-center text-gray-700 hover:text-blue-600">
-          <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <rect x="3" y="3" width="18" height="18" rx="2" ry="2" stroke-width="2" />
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v18M15 3v18M3 9h18M3 15h18" />
-          </svg>
-          <span>Salas</span>
-        </router-link>
-        <div class="text-gray-700">
-          <div class="flex items-center">
+      <nav class="space-y-6 mt-8">
+        <div class="space-y-2">
+          <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Atendimento</h3>
+          <router-link to="/dashboard" class="flex items-center text-gray-700 hover:text-blue-600">
             <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <rect x="4" y="3" width="16" height="18" rx="2" ry="2" stroke-width="2" />
-              <line x1="8" y1="7" x2="16" y2="7" stroke-width="2" />
-              <line x1="8" y1="11" x2="16" y2="11" stroke-width="2" />
-              <line x1="8" y1="15" x2="16" y2="15" stroke-width="2" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l9-9 9 9M4 10v10a1 1 0 001 1h3m10-11v10a1 1 0 01-1 1h-3m-6 0h6" />
             </svg>
-            <span>Comprovantes</span>
-          </div>
-          <router-link to="/comprovantes" class="flex items-center ml-6 mt-1 text-gray-700 hover:text-blue-600">
-            <span>Comprovantes</span>
+            <span>Início</span>
           </router-link>
-          <router-link to="/templates" class="flex items-center ml-6 text-gray-700 hover:text-blue-600">
-            <span>Templates</span>
+          <router-link to="/agendamentos" class="flex items-center text-gray-700 hover:text-blue-600">
+            <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <rect x="3" y="4" width="18" height="18" rx="2" ry="2" stroke-width="2"/>
+              <line x1="16" y1="2" x2="16" y2="6" stroke-width="2"/>
+              <line x1="8" y1="2" x2="8" y2="6" stroke-width="2"/>
+              <line x1="3" y1="10" x2="21" y2="10" stroke-width="2"/>
+            </svg>
+            <span>Atendimento</span>
           </router-link>
         </div>
-        <router-link to="/usuarios" class="flex items-center text-gray-700 hover:text-blue-600">
-          <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <circle cx="12" cy="8" r="4" stroke-width="2" />
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 21v-2a6 6 0 0112 0v2" />
-          </svg>
-          <span>Usuários</span>
-        </router-link>
-        <router-link to="/minha-assinatura" class="flex items-center text-gray-700 hover:text-blue-600">
-          <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <rect x="3" y="4" width="18" height="16" rx="2" ry="2" stroke-width="2" />
-            <line x1="3" y1="9" x2="21" y2="9" stroke-width="2" />
-          </svg>
-          <span>Minha Assinatura</span>
-        </router-link>
+        <div class="space-y-2">
+          <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Cadastros</h3>
+          <router-link to="/clientes" class="flex items-center text-gray-700 hover:text-blue-600">
+            <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <circle cx="12" cy="7" r="4" stroke-width="2" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 21v-2a6 6 0 0112 0v2" />
+            </svg>
+            <span>Clientes</span>
+          </router-link>
+          <router-link to="/servicos" class="flex items-center text-gray-700 hover:text-blue-600">
+            <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <rect x="2" y="7" width="20" height="14" rx="2" ry="2" stroke-width="2" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V5a4 4 0 018 0v2" />
+            </svg>
+            <span>Serviços</span>
+          </router-link>
+          <router-link to="/salas" class="flex items-center text-gray-700 hover:text-blue-600">
+            <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <rect x="3" y="3" width="18" height="18" rx="2" ry="2" stroke-width="2" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v18M15 3v18M3 9h18M3 15h18" />
+            </svg>
+            <span>Salas</span>
+          </router-link>
+        </div>
+        <div class="space-y-2">
+          <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Relatórios</h3>
+          <router-link to="/faturamento" class="flex items-center text-gray-700 hover:text-blue-600">
+            <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3v18h18M9 17v-4M13 17v-8M17 17V7" />
+            </svg>
+            <span>Faturamento</span>
+          </router-link>
+        </div>
+        <div class="space-y-2">
+          <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Conta</h3>
+          <router-link to="/configuracao" class="flex items-center text-gray-700 hover:text-blue-600">
+            <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <circle cx="12" cy="8" r="4" stroke-width="2" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 21v-2a6 6 0 0112 0v2" />
+            </svg>
+            <span>Perfil</span>
+          </router-link>
+          <router-link to="/usuarios" class="flex items-center text-gray-700 hover:text-blue-600">
+            <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <circle cx="12" cy="8" r="4" stroke-width="2" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 21v-2a6 6 0 0112 0v2" />
+            </svg>
+            <span>Usuários</span>
+          </router-link>
+          <router-link to="/minha-assinatura" class="flex items-center text-gray-700 hover:text-blue-600">
+            <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <rect x="3" y="4" width="18" height="16" rx="2" ry="2" stroke-width="2" />
+              <line x1="3" y1="9" x2="21" y2="9" stroke-width="2" />
+            </svg>
+            <span>Minha Assinatura</span>
+          </router-link>
+        </div>
       </nav>
     </aside>
   </div>


### PR DESCRIPTION
## Summary
- update the sidebar navigation with grouped sections and icons

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a9e72634832e890e75fa21940477