### PR TITLE
Improve account dropdown in header

### DIFF
--- a/src/components/HeaderUser.vue
+++ b/src/components/HeaderUser.vue
@@ -1,11 +1,21 @@
 <template>
   <header class="flex justify-between items-center mb-8">
     <h1 class="text-2xl font-semibold text-gray-800">{{ title }}</h1>
-    <div v-if="userEmail" class="relative flex items-center space-x-4">
-      <span class="text-gray-600">{{ userEmail }}</span>
-      <button @click="toggleMenu" class="px-3 py-2 bg-gray-200 rounded hover:bg-gray-300">Opções</button>
-      <div v-if="showMenu" class="absolute right-0 mt-2 w-40 bg-white border rounded shadow-md">
-        <router-link to="/configuracao" class="block px-4 py-2 hover:bg-gray-100">Configurações</router-link>
+    <div v-if="userEmail" class="relative">
+      <button @click="toggleMenu" class="flex items-center space-x-2 focus:outline-none">
+        <svg class="w-5 h-5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <circle cx="12" cy="8" r="4" stroke-width="2" />
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 21v-2a6 6 0 0112 0v2" />
+        </svg>
+        <span class="text-gray-600">{{ userEmail }}</span>
+        <svg class="w-4 h-4 text-gray-600 transition-transform" :class="{ 'rotate-180': showMenu }" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      <div v-if="showMenu" class="absolute right-0 mt-2 w-48 bg-white border rounded shadow-md">
+        <router-link to="/configuracao" class="block px-4 py-2 hover:bg-gray-100">Perfil</router-link>
+        <router-link to="/usuarios" class="block px-4 py-2 hover:bg-gray-100">Usuários</router-link>
+        <router-link to="/minha-assinatura" class="block px-4 py-2 hover:bg-gray-100">Assinatura</router-link>
         <button @click="handleLogout" class="w-full text-left px-4 py-2 hover:bg-gray-100">Sair</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- show a user icon, email and arrow in header
- open menu from email/arrow and add links to Perfil, Usuários and Assinatura

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b22f78ac832ea139f2ee3356b271