### PR TITLE
Fix filtering for calendar and week views

### DIFF
--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -169,13 +169,16 @@
 
         <div class="mt-8" v-show="viewMode === 'calendar'">
           <h3 class="text-lg font-medium mb-4">Calendário</h3>
-          <CalendarView :appointments="appointments" :getClientName="getClientName" />
+          <CalendarView
+            :appointments="processedAppointments"
+            :getClientName="getClientName"
+          />
         </div>
 
         <div class="mt-8" v-show="viewMode === 'week'">
           <h3 class="text-lg font-medium mb-4">Semana</h3>
           <WeekView
-            :appointments="appointments"
+            :appointments="processedAppointments"
             :getClientName="getClientName"
             @select="openDetails"
           />


### PR DESCRIPTION
## Summary
- ensure Calendar and Week views respect search filtering

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442868eca08320ac6b86746b879171