### PR TITLE
Add clear filters and reset calendar month

### DIFF
--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -71,6 +71,11 @@ export default {
         this.currentMonth++
       }
     },
+    goToCurrentMonth() {
+      const today = new Date()
+      this.currentYear = today.getFullYear()
+      this.currentMonth = today.getMonth()
+    },
     getAppointmentsForDay(day) {
       const month = String(this.currentMonth + 1).padStart(2, '0')
       const d = String(day).padStart(2, '0')

--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -61,6 +61,10 @@
             @click="exportCSV"
             class="bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700 w-full sm:w-auto"
           >Exportar</button>
+          <button
+            @click="clearFilters"
+            class="bg-gray-300 text-gray-800 px-4 py-2 rounded-lg hover:bg-gray-400 w-full sm:w-auto"
+          >Limpar</button>
         </div>
 
         <Modal v-if="showModal" @close="closeModal">
@@ -170,6 +174,7 @@
         <div class="mt-8" v-show="viewMode === 'calendar'">
           <h3 class="text-lg font-medium mb-4">Calendário</h3>
           <CalendarView
+            ref="calendarView"
             :appointments="processedAppointments"
             :getClientName="getClientName"
           />
@@ -385,6 +390,9 @@ export default {
     setViewMode(mode) {
       this.viewMode = mode
       this.showViewDropdown = false
+      if (mode === 'calendar' && this.$refs.calendarView && this.$refs.calendarView.goToCurrentMonth) {
+        this.$refs.calendarView.goToCurrentMonth()
+      }
     },
     openDetails(appointment) {
       this.selectedAppointment = appointment
@@ -410,6 +418,11 @@ export default {
       document.body.appendChild(link)
       link.click()
       document.body.removeChild(link)
+    },
+    clearFilters() {
+      this.searchQuery = ''
+      this.filterStartDate = ''
+      this.filterEndDate = ''
     }
   },
   watch: {


### PR DESCRIPTION
## Summary
- add 'Limpar' button to reset search filters
- reset calendar to current month whenever the calendar view is selected

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442b72a9d8832091f031bf4d8b80d7