### PR TITLE
Add FAQ and privacy pages

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,10 +1,21 @@
 <template>
-    <footer class="bg-gray-100 text-center text-sm text-gray-500 py-6">
-      <p>© 2025 Agenda Zen — Todos os direitos reservados</p>
-      <p><a href="#" class="hover:underline">Termos de uso</a> | <a href="#" class="hover:underline">Política de privacidade</a></p>
-    </footer>
-  </template>
-  
-  <script>
-  export default { name: 'Footer' }
-  </script>
+  <footer class="bg-gray-100 text-center text-sm text-gray-500 py-6 space-y-2">
+    <div class="space-x-4 text-blue-600">
+      <a href="https://www.instagram.com/agenda.zen" target="_blank" class="hover:underline">Instagram</a>
+      <a href="https://www.facebook.com/agenda.zen" target="_blank" class="hover:underline">Facebook</a>
+      <a href="https://x.com/agenda_zen" target="_blank" class="hover:underline">X</a>
+    </div>
+    <div class="space-x-2">
+      <a href="#" class="hover:underline">Termos de uso</a> |
+      <router-link to="/planos" class="hover:underline">Planos</router-link> |
+      <router-link to="/contato" class="hover:underline">Contato</router-link> |
+      <router-link to="/faq" class="hover:underline">FAQ</router-link> |
+      <router-link to="/politica-de-privacidade" class="hover:underline">Política de privacidade</router-link>
+    </div>
+    <p>© 2025 Agenda Zen — Todos os direitos reservados</p>
+  </footer>
+</template>
+
+<script>
+export default { name: 'Footer' }
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,6 +18,8 @@ import Templates from '../views/Templates.vue'
 import Contato from '../views/Contato.vue'
 import MinhaAssinatura from '../views/MinhaAssinatura.vue'
 import Faturamento from '../views/Faturamento.vue'
+import Faq from '../views/Faq.vue'
+import PoliticaPrivacidade from '../views/PoliticaPrivacidade.vue'
 
 
 const routes = [
@@ -39,6 +41,8 @@ const routes = [
   { path: '/buscar', name: 'SearchProfiles', component: SearchProfiles },
   { path: '/planos', name: 'Planos', component: Planos },
   { path: '/contato', name: 'Contato', component: Contato },
+  { path: '/faq', name: 'Faq', component: Faq },
+  { path: '/politica-de-privacidade', name: 'PoliticaDePrivacidade', component: PoliticaPrivacidade },
   { path: '/:slug', name: 'PublicPage', component: PublicPage },
 ]
 

--- a/src/views/Faq.vue
+++ b/src/views/Faq.vue
@@ -1,0 +1,41 @@
+<template>
+  <Navbar />
+  <section class="max-w-3xl mx-auto px-4 py-16">
+    <h1 class="text-3xl font-bold text-center mb-8">Perguntas Frequentes</h1>
+    <div class="space-y-6">
+      <div v-for="(faq, index) in faqs" :key="index" class="bg-white p-6 rounded-lg shadow">
+        <h2 class="font-semibold text-blue-600 mb-2">{{ faq.question }}</h2>
+        <p class="text-gray-700">{{ faq.answer }}</p>
+      </div>
+    </div>
+  </section>
+  <Footer />
+</template>
+
+<script>
+import Navbar from '../components/Navbar.vue'
+import Footer from '../components/Footer.vue'
+
+export default {
+  name: 'Faq',
+  components: { Navbar, Footer },
+  data() {
+    return {
+      faqs: [
+        {
+          question: 'Como me cadastro?',
+          answer: 'Clique em "Cadastre-se" no menu e preencha o formulário.'
+        },
+        {
+          question: 'Posso cancelar a qualquer momento?',
+          answer: 'Sim, você pode cancelar seu plano a hora que quiser sem taxas adicionais.'
+        },
+        {
+          question: 'Como entro em contato com o suporte?',
+          answer: 'Utilize a página de contato para nos enviar sua mensagem.'
+        }
+      ]
+    }
+  }
+}
+</script>

--- a/src/views/PoliticaPrivacidade.vue
+++ b/src/views/PoliticaPrivacidade.vue
@@ -1,0 +1,20 @@
+<template>
+  <Navbar />
+  <section class="max-w-3xl mx-auto px-4 py-16 space-y-4">
+    <h1 class="text-3xl font-bold text-center mb-4">Política de Privacidade</h1>
+    <p>Esta política descreve como tratamos seus dados pessoais e garante a transparência sobre o uso das suas informações.</p>
+    <p>Utilizamos seus dados apenas para prover nossos serviços de agendamento e nunca os compartilhamos com terceiros sem consentimento.</p>
+    <p>Ao utilizar o Agenda Zen você concorda com esta política. Em caso de dúvidas entre em contato conosco.</p>
+  </section>
+  <Footer />
+</template>
+
+<script>
+import Navbar from '../components/Navbar.vue'
+import Footer from '../components/Footer.vue'
+
+export default {
+  name: 'PoliticaPrivacidade',
+  components: { Navbar, Footer }
+}
+</script>


### PR DESCRIPTION
## Summary
- update footer with links to social media and new pages
- add FAQ page
- add privacy policy page
- register new routes for FAQ and privacy policy

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684436303614832eb44d47cfd49d3e7d