### PR TITLE
Add basic React Native mobile apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,12 @@ O diretório `supabase/schemas` contém os scripts SQL para criação das tabela
 - `src/` – código fonte em Vue (componentes, views e roteamento)
 - `public/` – arquivos estáticos
 - `supabase/` – scripts SQL de criação do banco de dados
+- `mobile/android` – aplicativo Android em React Native
+- `mobile/ios` – aplicativo iOS em React Native
+
+## Aplicativos móveis
+
+Os diretórios `mobile/android` e `mobile/ios` contêm versões iniciais dos apps em React Native.
+Cada um possui apenas as telas de **Login** e **Dashboard**.
 
 Contribuições são bem‑vindas! Sinta‑se à vontade para abrir _issues_ ou enviar _pull requests_.

--- a/mobile/android/App.js
+++ b/mobile/android/App.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import LoginScreen from './src/LoginScreen';
+import DashboardScreen from './src/DashboardScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Login">
+        <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen name="Dashboard" component={DashboardScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -1,0 +1,13 @@
+# App Android do Agenda Zen
+
+Este projeto é uma versão inicial do aplicativo Android utilizando React Native.
+Ele possui apenas duas telas: **Login** e **Dashboard**.
+
+Para instalar as dependências e rodar o aplicativo:
+
+```bash
+npm install
+npm start
+```
+
+Será necessário ter o ambiente do React Native configurado na sua máquina.

--- a/mobile/android/package.json
+++ b/mobile/android/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "agenda-zen-android",
+  "version": "0.1.0",
+  "private": true,
+  "main": "App.js",
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.73.2",
+    "@react-navigation/native": "^6.0.0",
+    "@react-navigation/native-stack": "^6.0.0"
+  }
+}

--- a/mobile/android/src/DashboardScreen.js
+++ b/mobile/android/src/DashboardScreen.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function DashboardScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Dashboard</Text>
+    </View>
+  );
+}

--- a/mobile/android/src/LoginScreen.js
+++ b/mobile/android/src/LoginScreen.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { View, Text, Button } from 'react-native';
+
+export default function LoginScreen({ navigation }) {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Login</Text>
+      <Button title="Entrar" onPress={() => navigation.navigate('Dashboard')} />
+    </View>
+  );
+}

--- a/mobile/ios/App.js
+++ b/mobile/ios/App.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import LoginScreen from './src/LoginScreen';
+import DashboardScreen from './src/DashboardScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Login">
+        <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen name="Dashboard" component={DashboardScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/mobile/ios/README.md
+++ b/mobile/ios/README.md
@@ -1,0 +1,14 @@
+# App iOS do Agenda Zen
+
+Versão inicial do aplicativo para iOS feita em React Native com apenas duas tel
+as: **Login** e **Dashboard**.
+
+Para executar o projeto:
+
+```bash
+npm install
+npm start
+```
+
+É necessário ter o ambiente do React Native instalado e um simulador ou disp
+ositivo iOS.

--- a/mobile/ios/package.json
+++ b/mobile/ios/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "agenda-zen-ios",
+  "version": "0.1.0",
+  "private": true,
+  "main": "App.js",
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.73.2",
+    "@react-navigation/native": "^6.0.0",
+    "@react-navigation/native-stack": "^6.0.0"
+  }
+}

--- a/mobile/ios/src/DashboardScreen.js
+++ b/mobile/ios/src/DashboardScreen.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function DashboardScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Dashboard</Text>
+    </View>
+  );
+}

--- a/mobile/ios/src/LoginScreen.js
+++ b/mobile/ios/src/LoginScreen.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { View, Text, Button } from 'react-native';
+
+export default function LoginScreen({ navigation }) {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Login</Text>
+      <Button title="Entrar" onPress={() => navigation.navigate('Dashboard')} />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- create initial Android and iOS apps with login and dashboard screens
- document mobile directories in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684452eb7c20832e851596625ef61da1