### PR TITLE
Add mobile app guides

### DIFF
--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -1,13 +1,46 @@
 # App Android do Agenda Zen
 
-Este projeto é uma versão inicial do aplicativo Android utilizando React Native.
-Ele possui apenas duas telas: **Login** e **Dashboard**.
+## Informações gerais
 
-Para instalar as dependências e rodar o aplicativo:
+Aplicativo Android escrito em React Native que complementa a versão web do Agenda
+Zen. Atualmente conta apenas com as telas de **Login** e **Dashboard**.
+
+## Como rodar localmente
+
+1. Verifique se o ambiente do React Native está configurado (Node.js, JDK e
+   Android Studio com um emulador ou dispositivo conectado).
+2. Instale as dependências:
+   ```bash
+   npm install
+   ```
+3. Inicie o Metro bundler:
+   ```bash
+   npm start
+   ```
+4. Em outro terminal, execute o app:
+   ```bash
+   npx react-native run-android
+   ```
+
+## Como gerar um executável para rodar em dispositivos de teste
+
+Para gerar um APK de testes utilize:
 
 ```bash
-npm install
-npm start
+cd android
+./gradlew assembleRelease
 ```
 
-Será necessário ter o ambiente do React Native configurado na sua máquina.
+O arquivo será criado em `android/app/build/outputs/apk/release/`.
+
+## Como fazer deploy em produção
+
+1. Crie uma chave de assinatura e configure-a em `android/gradle.properties`.
+2. Gere o bundle de produção:
+   ```bash
+   ./gradlew bundleRelease
+   ```
+3. Envie o arquivo `.aab` gerado para a Google Play Console.
+
+Consulte a [documentação do React Native](https://reactnative.dev/docs/signed-apk-android)
+para detalhes adicionais.

--- a/mobile/ios/README.md
+++ b/mobile/ios/README.md
@@ -1,14 +1,42 @@
 # App iOS do Agenda Zen
 
-Versão inicial do aplicativo para iOS feita em React Native com apenas duas tel
-as: **Login** e **Dashboard**.
+## Informações gerais
 
-Para executar o projeto:
+Versão para iOS desenvolvida em React Native que acompanha a aplicação web do Agenda Zen. Neste estágio inicial possui apenas as telas de **Login** e **Dashboard**.
 
-```bash
-npm install
-npm start
-```
+## Como rodar localmente
 
-É necessário ter o ambiente do React Native instalado e um simulador ou disp
-ositivo iOS.
+1. Tenha o ambiente do React Native configurado no macOS (Xcode e CocoaPods).
+2. Instale as dependências:
+   ```bash
+   npm install
+   ```
+3. Instale as bibliotecas nativas:
+   ```bash
+   npx pod-install ios
+   ```
+4. Inicie o bundler:
+   ```bash
+   npm start
+   ```
+5. Em outro terminal execute:
+   ```bash
+   npx react-native run-ios
+   ```
+   O app será aberto no simulador ou dispositivo conectado.
+
+## Como gerar um executável para rodar em dispositivos de teste
+
+Para distribuir em aparelhos de teste gere um arquivo `.ipa` através de um archivamento no Xcode:
+
+1. Abra `ios/AgendaZen.xcworkspace`.
+2. Selecione `Product` > `Archive`.
+3. Escolha **Distribute App** e exporte no formato Ad Hoc.
+
+## Como fazer deploy em produção
+
+1. Gere os certificados e perfis de provisionamento na Apple Developer.
+2. No Xcode, após arquivar o projeto, selecione **Upload to App Store**.
+3. Finalize o envio pelo App Store Connect.
+
+Mais detalhes estão na [documentação do React Native](https://reactnative.dev/docs/publishing-to-app-store).


### PR DESCRIPTION
## Summary
- expand Android README with local run, build and deploy steps
- expand iOS README with local run, build and deploy steps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68445628a164832eae1c2191280e7ef4