### PR TITLE
Fix npm start for mobile apps

### DIFF
--- a/mobile/android/package.json
+++ b/mobile/android/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "main": "App.js",
+  "scripts": {
+    "start": "react-native start"
+  },
   "dependencies": {
     "react": "18.2.0",
     "react-native": "0.73.2",

--- a/mobile/ios/package.json
+++ b/mobile/ios/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "main": "App.js",
+  "scripts": {
+    "start": "react-native start"
+  },
   "dependencies": {
     "react": "18.2.0",
     "react-native": "0.73.2",


### PR DESCRIPTION
## Summary
- add `react-native start` script to android and ios apps

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445f449ba4832e946465e7d6aa0dcb