### PR TITLE
Fix iOS README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ O diretório `supabase/schemas` contém os scripts SQL para criação das tabela
 - `src/` – código fonte em Vue (componentes, views e roteamento)
 - `public/` – arquivos estáticos
 - `supabase/` – scripts SQL de criação do banco de dados
-- `mobile/android` – aplicativo Android em React Native
-- `mobile/ios` – aplicativo iOS em React Native
+- `mobile/android` – código-fonte do app Android em React Native (sem o projeto nativo)
+- `mobile/ios` – código-fonte do app iOS em React Native (sem o projeto nativo)
 
 ## Aplicativos móveis
 
-Os diretórios `mobile/android` e `mobile/ios` contêm versões iniciais dos apps em React Native.
+Os diretórios `mobile/android` e `mobile/ios` trazem apenas o código JavaScript das versões móveis em React Native.
+Para rodar os apps é necessário criar projetos nativos à parte e incorporar esses arquivos.
 Cada um possui apenas as telas de **Login** e **Dashboard**.
 
 Contribuições são bem‑vindas! Sinta‑se à vontade para abrir _issues_ ou enviar _pull requests_.

--- a/mobile/ios/README.md
+++ b/mobile/ios/README.md
@@ -3,23 +3,23 @@
 ## Informações gerais
 
 Versão para iOS desenvolvida em React Native que acompanha a aplicação web do Agenda Zen. Neste estágio inicial possui apenas as telas de **Login** e **Dashboard**.
+Este diretório contém somente o código JavaScript do app (arquivos `App.js` e `src/`).
+O projeto nativo do Xcode não está incluso.
 
 ## Como rodar localmente
 
 1. Tenha o ambiente do React Native configurado no macOS (Xcode e CocoaPods).
-2. Instale as dependências:
+2. Crie um novo projeto React Native com `npx react-native init AgendaZen`.
+3. Copie deste diretório os arquivos `App.js` e a pasta `src/` para a raiz do novo projeto.
+4. Dentro da pasta `ios` do projeto recém-criado execute:
    ```bash
-   npm install
+   npx pod-install
    ```
-3. Instale as bibliotecas nativas:
-   ```bash
-   npx pod-install ios
-   ```
-4. Inicie o bundler:
+5. Na raiz do projeto, inicie o bundler:
    ```bash
    npm start
    ```
-5. Em outro terminal execute:
+6. Em outro terminal execute:
    ```bash
    npx react-native run-ios
    ```


### PR DESCRIPTION
## Summary
- clarify that `mobile/ios` and `mobile/android` contain only JS sources
- update iOS README with proper steps to create a native project

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: network access)*

------
https://chatgpt.com/codex/tasks/task_e_68445eaa9e3c832e8de0578a0b9fe13a