### PR TITLE
Fix Android README instructions

### DIFF
--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -3,28 +3,34 @@
 ## Informações gerais
 
 Aplicativo Android escrito em React Native que complementa a versão web do Agenda
-Zen. Atualmente conta apenas com as telas de **Login** e **Dashboard**.
+Zen. Atualmente conta apenas com as telas de **Login** e **Dashboard**. Este
+diretório contém **somente** o código JavaScript do app (`App.js` e a pasta
+`src/`). O projeto nativo do Android (arquivos Gradle) não está incluso para
+manter o repositório enxuto.
 
 ## Como rodar localmente
 
 1. Verifique se o ambiente do React Native está configurado (Node.js, JDK e
    Android Studio com um emulador ou dispositivo conectado).
-2. Instale as dependências:
+2. Crie um novo projeto React Native com `npx react-native init AgendaZen`.
+3. Copie deste diretório os arquivos `App.js` e a pasta `src/` para a raiz do novo
+   projeto criado.
+4. Dentro da pasta do novo projeto, instale as dependências:
    ```bash
    npm install
    ```
-3. Inicie o Metro bundler:
+5. Inicie o Metro bundler:
    ```bash
    npm start
    ```
-4. Em outro terminal, execute o app:
+6. Em outro terminal, execute o app:
    ```bash
    npx react-native run-android
    ```
 
 ## Como gerar um executável para rodar em dispositivos de teste
 
-Para gerar um APK de testes utilize:
+Para gerar um APK de testes, dentro da pasta `android` do novo projeto, execute:
 
 ```bash
 cd android
@@ -35,8 +41,8 @@ O arquivo será criado em `android/app/build/outputs/apk/release/`.
 
 ## Como fazer deploy em produção
 
-1. Crie uma chave de assinatura e configure-a em `android/gradle.properties`.
-2. Gere o bundle de produção:
+1. Crie uma chave de assinatura e configure-a em `android/gradle.properties` do projeto.
+2. Gere o bundle de produção dentro da pasta `android` do projeto:
    ```bash
    ./gradlew bundleRelease
    ```


### PR DESCRIPTION
## Summary
- clarify that the repo only contains JavaScript code for the Android app
- document how to create a new React Native project and copy the files
- adjust release and deployment instructions to reference the new project

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm start` *(fails: react-native not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844620835a0832ea2c5f27bad93f671