### PR TITLE
Fix alignment of filter controls

### DIFF
--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -12,42 +12,12 @@
       <HeaderUser title="Agendamentos" />
       <section>
         <div class="flex flex-col sm:flex-row sm:items-center mb-4 gap-2">
-          <div class="flex flex-col flex-grow sm:max-w-xs">
-            <input
-              v-model="searchQuery"
-              type="text"
-              placeholder="Buscar..."
-              class="border px-3 py-2 rounded-lg"
-            />
-            <div class="mt-1 flex items-center space-x-2">
-              <span class="text-xs text-gray-600">Modo de exibição:</span>
-              <div class="relative">
-                <button
-                  @click="showViewDropdown = !showViewDropdown"
-                  class="px-4 py-2 bg-gray-200 rounded-lg"
-                >
-                  {{ viewMode === 'list' ? 'Lista' : viewMode === 'calendar' ? 'Calendário' : 'Semana' }}
-                </button>
-                <div
-                  v-if="showViewDropdown"
-                  class="absolute right-0 mt-2 w-32 bg-white border rounded shadow"
-                >
-                  <button
-                    @click="setViewMode('list')"
-                    class="block w-full text-left px-4 py-2 hover:bg-gray-100"
-                  >Lista</button>
-                  <button
-                    @click="setViewMode('calendar')"
-                    class="block w-full text-left px-4 py-2 hover:bg-gray-100"
-                  >Calendário</button>
-                  <button
-                    @click="setViewMode('week')"
-                    class="block w-full text-left px-4 py-2 hover:bg-gray-100"
-                  >Semana</button>
-                </div>
-              </div>
-            </div>
-          </div>
+          <input
+            v-model="searchQuery"
+            type="text"
+            placeholder="Buscar..."
+            class="border px-3 py-2 rounded-lg flex-grow sm:max-w-xs"
+          />
           <input
             v-model="filterStartDate"
             type="date"
@@ -70,6 +40,34 @@
             @click="exportCSV"
             class="bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700 w-full sm:w-auto"
           >Exportar</button>
+        </div>
+        <div class="mb-4 flex items-center space-x-2">
+          <span class="text-xs text-gray-600">Modo de exibição:</span>
+          <div class="relative">
+            <button
+              @click="showViewDropdown = !showViewDropdown"
+              class="px-4 py-2 bg-gray-200 rounded-lg"
+            >
+              {{ viewMode === 'list' ? 'Lista' : viewMode === 'calendar' ? 'Calendário' : 'Semana' }}
+            </button>
+            <div
+              v-if="showViewDropdown"
+              class="absolute right-0 mt-2 w-32 bg-white border rounded shadow"
+            >
+              <button
+                @click="setViewMode('list')"
+                class="block w-full text-left px-4 py-2 hover:bg-gray-100"
+              >Lista</button>
+              <button
+                @click="setViewMode('calendar')"
+                class="block w-full text-left px-4 py-2 hover:bg-gray-100"
+              >Calendário</button>
+              <button
+                @click="setViewMode('week')"
+                class="block w-full text-left px-4 py-2 hover:bg-gray-100"
+              >Semana</button>
+            </div>
+          </div>
         </div>
 
         <Modal v-if="showModal" @close="closeModal">


### PR DESCRIPTION
## Summary
- adjust Agendamentos view layout so the search, date and action buttons sit on one row
- move display mode selector below the filters

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b1b2408c8320887f2f9109e63a77