### PR TITLE
Unify calendar styling with blue line

### DIFF
--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -26,7 +26,7 @@
         v-for="day in daysInMonth"
         :key="day"
         class="border border-gray-200 h-24 p-1 overflow-auto bg-white"
-        :class="{ 'bg-blue-50': isToday(day) }"
+        :class="{ 'bg-blue-50 border-l-4 border-blue-500': isToday(day) }"
       >
         <div class="text-center font-medium">{{ day }}</div>
         <ul>

--- a/src/components/WeekView.vue
+++ b/src/components/WeekView.vue
@@ -29,7 +29,7 @@
           v-for="(day, idx) in daysOfWeek"
           :key="day"
           class="font-semibold text-center border px-1 bg-gray-50"
-          :class="{ 'bg-blue-50': isToday(idx) }"
+          :class="{ 'bg-blue-50 border-l-4 border-blue-500': isToday(idx) }"
         >
           {{ day }}
         </div>
@@ -40,6 +40,7 @@
             v-for="i in 7"
             :key="time + '-' + i"
             class="border h-16 p-1 overflow-auto bg-white"
+            :class="{ 'border-l-4 border-blue-500': isToday(i - 1) }"
           >
             <ul>
               <li


### PR DESCRIPTION
## Summary
- add blue left border for current day in monthly calendar
- highlight current day column with same style in week view

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bd55e2fc8320be8d5810517fb197