### PR TITLE
Remove vertical line from WeekView

### DIFF
--- a/src/components/WeekView.vue
+++ b/src/components/WeekView.vue
@@ -40,7 +40,7 @@
             v-for="i in 7"
             :key="time + '-' + i"
             class="border h-16 p-1 overflow-auto bg-white"
-            :class="{ 'border-l-4 border-blue-500': isToday(i - 1) }"
+            :class="{ 'bg-blue-50': isToday(i - 1) }"
           >
             <ul>
               <li


### PR DESCRIPTION
## Summary
- tweak WeekView styling to remove the blue vertical line and only keep a light highlight for the current day column

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844be55f31c8320bf745c71275b8349