### PR TITLE
Standardize table style

### DIFF
--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -127,8 +127,9 @@
 
         <div class="mt-8" v-show="viewMode === 'list'">
           <h3 class="text-lg font-medium mb-4">Agendamentos</h3>
-          <div class="bg-white p-6 rounded-lg shadow overflow-x-auto">
-            <table class="min-w-full text-left">
+          <div class="bg-white p-4 rounded-lg shadow">
+            <div class="overflow-x-auto">
+              <table class="min-w-full text-left">
               <thead class="bg-gray-50">
                 <tr>
                   <th @click="sortBy('datetime')" class="px-4 py-2 font-medium text-gray-700 cursor-pointer">

--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -11,7 +11,7 @@
       </div>
       <HeaderUser title="Clientes" />
 
-      <section class="bg-white p-6 rounded-lg shadow">
+      <section class="bg-white p-4 rounded-lg shadow">
         <div class="flex justify-between items-center mb-4">
           <h3 class="text-lg font-medium">Clientes cadastrados</h3>
           <div class="flex items-center space-x-3">

--- a/src/views/Comprovantes.vue
+++ b/src/views/Comprovantes.vue
@@ -12,7 +12,7 @@
       <HeaderUser title="Comprovantes" />
 
 
-      <section class="bg-white p-6 rounded-lg shadow space-y-4">
+      <section class="bg-white p-4 rounded-lg shadow space-y-4">
         <div class="flex justify-between items-center">
           <h3 class="text-lg font-medium">Comprovantes Gerados</h3>
           <button @click="showGenerateModal = true" class="btn">Novo Comprovante</button>

--- a/src/views/Faturamento.vue
+++ b/src/views/Faturamento.vue
@@ -11,7 +11,7 @@
       </div>
       <HeaderUser title="Relatório de Faturamento" />
 
-      <section class="bg-white p-6 rounded-lg shadow space-y-4">
+      <section class="bg-white p-4 rounded-lg shadow space-y-4">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
           <div>
             <label class="block text-sm font-medium text-gray-700">De</label>
@@ -44,7 +44,7 @@
         </div>
       </section>
 
-      <section class="bg-white p-6 rounded-lg shadow space-y-4">
+      <section class="bg-white p-4 rounded-lg shadow space-y-4">
         <div class="overflow-x-auto">
           <table class="min-w-full text-left">
             <thead class="bg-gray-50">

--- a/src/views/Planos.vue
+++ b/src/views/Planos.vue
@@ -2,15 +2,16 @@
   <Navbar />
   <section class="max-w-5xl mx-auto px-4 py-16">
     <h1 class="text-3xl font-bold text-center mb-8">Conheça nossos planos</h1>
-    <div class="overflow-x-auto">
-      <table class="min-w-full bg-white border border-gray-200 rounded-lg">
-        <thead>
-          <tr class="bg-gray-50 text-gray-700">
-            <th class="px-4 py-2 text-left">Recursos</th>
-            <th class="px-4 py-2">Básico</th>
-            <th class="px-4 py-2">Plus</th>
-          </tr>
-        </thead>
+    <div class="bg-white p-4 rounded-lg shadow">
+      <div class="overflow-x-auto">
+        <table class="min-w-full text-left">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="px-4 py-2 font-medium text-gray-700">Recursos</th>
+              <th class="px-4 py-2 font-medium text-gray-700 text-center">Básico</th>
+              <th class="px-4 py-2 font-medium text-gray-700 text-center">Plus</th>
+            </tr>
+          </thead>
         <tbody>
           <tr>
             <td class="border-t px-4 py-2 text-gray-600">Valor</td>
@@ -54,7 +55,8 @@
           </tr>
         </tbody>
       </table>
-    </div>
+        </div>
+      </div>
     <div class="text-center mt-8">
       <router-link to="/cadastro" class="btn">
         Contratar plano

--- a/src/views/Salas.vue
+++ b/src/views/Salas.vue
@@ -11,7 +11,7 @@
       </div>
       <HeaderUser title="Salas" />
 
-      <section class="bg-white p-6 rounded-lg shadow">
+      <section class="bg-white p-4 rounded-lg shadow">
         <div class="flex justify-between items-center mb-4">
           <h3 class="text-lg font-medium">Salas cadastradas</h3>
           <div class="flex items-center space-x-3">

--- a/src/views/Servicos.vue
+++ b/src/views/Servicos.vue
@@ -11,7 +11,7 @@
       </div>
       <HeaderUser title="Serviços" />
 
-      <section class="bg-white p-6 rounded-lg shadow">
+      <section class="bg-white p-4 rounded-lg shadow">
         <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-4 space-y-4 sm:space-y-0">
           <h3 class="text-lg font-medium">Serviços cadastrados</h3>
           <div class="flex flex-col sm:flex-row items-stretch sm:items-center w-full sm:w-auto space-y-2 sm:space-y-0 sm:space-x-3">

--- a/src/views/Templates.vue
+++ b/src/views/Templates.vue
@@ -11,7 +11,7 @@
       </div>
       <HeaderUser title="Templates" />
 
-      <section class="bg-white p-6 rounded-lg shadow space-y-4">
+      <section class="bg-white p-4 rounded-lg shadow space-y-4">
         <div class="flex justify-between items-center">
           <h3 class="text-lg font-medium">Templates</h3>
           <button @click="showTemplateModal = true" class="btn">Novo Template</button>

--- a/src/views/Usuarios.vue
+++ b/src/views/Usuarios.vue
@@ -10,7 +10,7 @@
         </button>
       </div>
       <HeaderUser title="Usuários" />
-      <section class="bg-white p-6 rounded-lg shadow">
+      <section class="bg-white p-4 rounded-lg shadow">
         <h3 class="text-lg font-medium mb-4">Cadastrar novo usuário</h3>
         <form @submit.prevent="handleAddUser" class="space-y-4">
           <div>
@@ -29,7 +29,7 @@
         <p v-if="errorMessage" class="text-red-600 mt-4">{{ errorMessage }}</p>
       </section>
 
-      <section class="bg-white p-6 rounded-lg shadow">
+      <section class="bg-white p-4 rounded-lg shadow">
         <div class="flex justify-between items-center mb-4">
           <h3 class="text-lg font-medium">Usuários cadastrados</h3>
           <input


### PR DESCRIPTION
## Summary
- unify table wrappers across pages with same padding and overflow structure
- adjust pricing page table markup to match dashboard style

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bfbb7f708320ac70cae39449dce9