### PR TITLE
Improve table action styles

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -6,3 +6,18 @@
 .btn {
   @apply bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700;
 }
+
+/* Smaller variant for table actions */
+.btn-sm {
+  @apply px-3 py-1 text-sm;
+}
+
+/* Danger style for destructive actions */
+.btn-danger {
+  @apply bg-red-600 text-white hover:bg-red-700;
+}
+
+/* Success style variant */
+.btn-success {
+  @apply bg-green-600 text-white hover:bg-green-700;
+}

--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -162,9 +162,9 @@
                   <td class="px-4 py-2">{{ getServiceName(appointment.service_id) }}</td>
                   <td class="px-4 py-2">{{ appointment.duration }}</td>
                   <td class="px-4 py-2">{{ appointment.description }}</td>
-                  <td class="px-4 py-2 text-right">
-                    <button @click="openModal(appointment)" class="text-blue-600 hover:underline">Editar</button>
-                    <button @click="handleDeleteAppointment(appointment.id)" class="text-red-600 hover:underline ml-2">Excluir</button>
+                  <td class="px-4 py-2 text-right space-x-2">
+                    <button @click="openModal(appointment)" class="btn btn-sm">Editar</button>
+                    <button @click="handleDeleteAppointment(appointment.id)" class="btn btn-sm btn-danger">Excluir</button>
                   </td>
                 </tr>
                 <tr v-if="processedAppointments.length === 0">

--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -54,13 +54,13 @@
                     :href="whatsappLink(client.phone)"
                     target="_blank"
                     rel="noopener"
-                    class="text-green-600 hover:underline"
+                    class="btn btn-sm btn-success"
                   >
                     WhatsApp
                   </a>
                   <button
                     @click="handleDeleteClient(client.id)"
-                    class="text-red-600 hover:underline"
+                    class="btn btn-sm btn-danger"
                   >
                     Excluir
                   </button>

--- a/src/views/Comprovantes.vue
+++ b/src/views/Comprovantes.vue
@@ -33,7 +33,7 @@
                 <td class="px-4 py-2">{{ r.start_date }} - {{ r.end_date }}</td>
                 <td class="px-4 py-2">{{ r.created_at.split('T')[0] }}</td>
                 <td class="px-4 py-2 text-right">
-                  <button @click="showReceipt(r.content)" class="text-blue-600 hover:underline">Ver</button>
+                  <button @click="showReceipt(r.content)" class="btn btn-sm">Ver</button>
                 </td>
               </tr>
               <tr v-if="receipts.length === 0">

--- a/src/views/Salas.vue
+++ b/src/views/Salas.vue
@@ -48,7 +48,7 @@
                 <td class="px-4 py-2 text-right">
                   <button
                     @click="handleDeleteRoom(room.id)"
-                    class="text-red-600 hover:underline"
+                    class="btn btn-sm btn-danger"
                   >
                     Excluir
                   </button>

--- a/src/views/Servicos.vue
+++ b/src/views/Servicos.vue
@@ -54,13 +54,13 @@
                 <td class="px-4 py-2 text-right space-x-2">
                   <button
                     @click="openModal(service)"
-                    class="text-blue-600 hover:underline"
+                    class="btn btn-sm"
                   >
                     Editar
                   </button>
                   <button
                     @click="handleDeleteService(service.id)"
-                    class="text-red-600 hover:underline"
+                    class="btn btn-sm btn-danger"
                   >
                     Excluir
                   </button>


### PR DESCRIPTION
## Summary
- add small, danger, and success button variants
- restyle action links in tables to use proper buttons

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844c1d7b60c8320af75adcfd8ed609b