### PR TITLE
Fix missing closing div in Agendamentos view

### DIFF
--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -173,6 +173,7 @@
               </tbody>
             </table>
           </div>
+          </div>
         </div>
 
         <div class="mt-8" v-show="viewMode === 'calendar'">


### PR DESCRIPTION
## Summary
- fix HTML structure by closing the list view container

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c2ec4f40832082e6c350189168c6