### PR TITLE
Allow 10 or 11 digit phone numbers

### DIFF
--- a/src/utils/phone.js
+++ b/src/utils/phone.js
@@ -1,16 +1,25 @@
 export function phoneMask(value) {
-  const digits = value.replace(/\D/g, '').slice(0, 10)
-  const part1 = digits.slice(0, 2)
-  const part2 = digits.slice(2, 6)
-  const part3 = digits.slice(6, 10)
-  if (digits.length > 6) {
-    return `(${part1}) ${part2}-${part3}`
-  } else if (digits.length > 2) {
-    return `(${part1}) ${part2}`
-  } else if (digits.length > 0) {
-    return `(${part1}`
+  const digits = value.replace(/\D/g, '').slice(0, 11)
+  const ddd = digits.slice(0, 2)
+
+  if (digits.length <= 2) {
+    return digits ? `(${ddd}` : ''
   }
-  return ''
+
+  if (digits.length <= 6) {
+    const part = digits.slice(2)
+    return `(${ddd}) ${part}`
+  }
+
+  if (digits.length <= 10) {
+    const part2 = digits.slice(2, 6)
+    const part3 = digits.slice(6)
+    return `(${ddd}) ${part2}${part3 ? `-${part3}` : ''}`
+  }
+
+  const part2 = digits.slice(2, 7)
+  const part3 = digits.slice(7)
+  return `(${ddd}) ${part2}-${part3}`
 }
 
 export function digitsOnly(value) {


### PR DESCRIPTION
## Summary
- update phone mask to support 10- or 11-digit numbers

## Testing
- `npm run test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c438a28c8320ad0400b0c1f2c4ef