### PR TITLE
Fix date field alignment in revenue report

### DIFF
--- a/src/views/Faturamento.vue
+++ b/src/views/Faturamento.vue
@@ -12,7 +12,7 @@
       <HeaderUser title="Relatório de Faturamento" />
 
       <section class="bg-white p-4 rounded-lg shadow space-y-4">
-        <div class="grid grid-cols-1 md:grid-cols-4 gap-4 items-end">
+        <div class="grid grid-cols-1 md:grid-cols-4 gap-4 items-start">
           <div>
             <label class="block text-sm font-medium text-gray-700">Serviços</label>
             <div class="mt-1 space-y-1">


### PR DESCRIPTION
## Summary
- align date filters with the service list on the revenue report screen

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844cda0894c832091546d56bc39f359