### PR TITLE
Move group by filter below date inputs

### DIFF
--- a/src/views/Faturamento.vue
+++ b/src/views/Faturamento.vue
@@ -34,14 +34,14 @@
                 <input type="date" v-model="filterEnd" class="w-full mt-1 px-4 py-2 border rounded-md" />
               </div>
             </div>
-          </div>
-          <div class="md:col-span-2 md:col-start-2 flex flex-col">
-            <label class="block text-sm font-medium text-gray-700 mb-1">Agrupar por</label>
-            <select v-model="groupBy" class="w-full px-4 py-2 border rounded-md">
-              <option value="mes">Mês</option>
-              <option value="semana">Semana</option>
-              <option value="dia">Dia</option>
-            </select>
+            <div class="flex flex-col mt-3">
+              <label class="block text-sm font-medium text-gray-700 mb-1">Agrupar por</label>
+              <select v-model="groupBy" class="w-full px-4 py-2 border rounded-md">
+                <option value="mes">Mês</option>
+                <option value="semana">Semana</option>
+                <option value="dia">Dia</option>
+              </select>
+            </div>
           </div>
         </div>
         <div class="flex justify-end">


### PR DESCRIPTION
## Summary
- adjust layout of revenue filter

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d0011d0083208c0182099673a6e0