### PR TITLE
Add Pix placeholder and info

### DIFF
--- a/public/icons/fake-qr.svg
+++ b/public/icons/fake-qr.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+  <rect width="256" height="256" fill="#e2e8f0"/>
+  <rect x="24" y="24" width="64" height="64" fill="#000"/>
+  <rect x="168" y="24" width="64" height="64" fill="#000"/>
+  <rect x="24" y="168" width="64" height="64" fill="#000"/>
+  <rect x="96" y="96" width="64" height="64" fill="#000"/>
+  <rect x="168" y="168" width="64" height="64" fill="#000"/>
+</svg>

--- a/src/views/PagamentoPlus.vue
+++ b/src/views/PagamentoPlus.vue
@@ -10,6 +10,7 @@
         </button>
       </div>
       <HeaderUser title="Pagamento" />
+      <img src="/icons/pix.svg" alt="Pagamento Pix" class="w-24 h-24 mx-auto" />
 
       <nav class="mb-6 space-x-2">
         <button
@@ -97,7 +98,11 @@
 
       <section v-if="activeTab === 'pix'" class="space-y-6 max-w-3xl">
         <div class="text-center space-y-4">
-          <img src="/icons/pix.svg" alt="QR Code Pix" class="w-32 h-32 mx-auto" />
+          <img src="/icons/fake-qr.svg" alt="QR Code Pix" class="w-32 h-32 mx-auto" />
+          <p class="font-semibold">Código de pagamento</p>
+          <p>Copie e cole o código abaixo no app da sua instituição financeira para finalizar a compra.</p>
+          <p class="font-semibold">Valor do pagamento</p>
+          <p class="text-lg font-semibold">R$ 67,00</p>
           <input type="text" v-model="pixCode" readonly class="w-full px-4 py-2 border rounded-md text-center" />
         </div>
       </section>


### PR DESCRIPTION
## Summary
- show Pix image at the top of payment page
- add placeholder QR code with instructions and payment value

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844dc3dd27c832097923159b4fb4615