### PR TITLE
Add countdown timer and fix responsive images

### DIFF
--- a/src/components/AboutSection.vue
+++ b/src/components/AboutSection.vue
@@ -2,7 +2,7 @@
     <section class="px-8 py-16">
       <div class="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
         <div>
-          <img src="/about-illustration.png" alt="Ilustração sobre agendamento" class="w-full h-auto max-w-md mx-auto" />
+          <img src="/about-illustration.png" alt="Ilustração sobre agendamento" class="w-full h-auto mx-auto" />
         </div>
         <div>
           <h2 class="text-2xl font-bold mb-4">O que é o Agenda Zen?</h2>

--- a/src/components/HeroBanner.vue
+++ b/src/components/HeroBanner.vue
@@ -9,9 +9,12 @@
                 <router-link to="/login" class="bg-white border border-blue-600 text-blue-600 px-6 py-2 rounded hover:bg-blue-100">Entrar</router-link>
                 <router-link to="/cadastro" class="btn">Criar conta</router-link>
             </div>
+            <div class="mt-6 text-2xl text-blue-600 font-semibold">
+              Tempo restante: {{ formattedTime }}
+            </div>
           </div>
           <div>
-            <img src="/hero-illustration.png" alt="Ilustração profissional usando a plataforma" class="w-full h-auto max-w-md mx-auto">
+            <img src="/hero-illustration.png" alt="Ilustração profissional usando a plataforma" class="w-full h-auto mx-auto">
           </div>
         </div>
       </div>
@@ -19,5 +22,32 @@
   </template>
   
   <script>
-  export default { name: 'HeroBanner' }
+  export default {
+    name: 'HeroBanner',
+    data() {
+      return {
+        timeLeft: 300,
+        intervalId: null
+      }
+    },
+    computed: {
+      formattedTime() {
+        const minutes = Math.floor(this.timeLeft / 60).toString().padStart(2, '0')
+        const seconds = (this.timeLeft % 60).toString().padStart(2, '0')
+        return `${minutes}:${seconds}`
+      }
+    },
+    mounted() {
+      this.intervalId = setInterval(() => {
+        if (this.timeLeft > 0) {
+          this.timeLeft--
+        } else {
+          clearInterval(this.intervalId)
+        }
+      }, 1000)
+    },
+    beforeUnmount() {
+      clearInterval(this.intervalId)
+    }
+  }
   </script>


### PR DESCRIPTION
## Summary
- remove max width limit from hero image
- show a 5-minute countdown on homepage hero banner
- improve about section image responsiveness

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e108ef308320a9063f0e1b5ba461