### PR TITLE
Enlarge Pix payment logo

### DIFF
--- a/src/views/PagamentoPlus.vue
+++ b/src/views/PagamentoPlus.vue
@@ -97,7 +97,7 @@
 
       <section v-if="activeTab === 'pix'" class="space-y-6 max-w-3xl">
         <div class="text-center space-y-4">
-          <img src="/logo_pix.png" alt="Logo Pix" class="mx-auto w-48 h-auto" />
+          <img src="/logo_pix.png" alt="Logo Pix" class="mx-auto w-64 h-auto" />
           <p class="font-semibold">Código de pagamento</p>
           <p>Copie e cole o código abaixo no app da sua instituição financeira para finalizar a compra.</p>
           <p class="font-semibold">Valor do pagamento</p>


### PR DESCRIPTION
## Summary
- expand the Pix logo size on the payment screen

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456bb616f8832085315df5b3ff778e