### PR TITLE
Increase Pix logo size by 10%

### DIFF
--- a/src/views/PagamentoPlus.vue
+++ b/src/views/PagamentoPlus.vue
@@ -97,7 +97,8 @@
 
       <section v-if="activeTab === 'pix'" class="space-y-6 max-w-3xl">
         <div class="text-center space-y-4">
-          <img src="/logo_pix.png" alt="Logo Pix" class="mx-auto w-64 h-auto" />
+          <!-- Increase the Pix logo size by about 10% -->
+          <img src="/logo_pix.png" alt="Logo Pix" class="mx-auto w-[17.6rem] h-auto" />
           <p class="font-semibold">Código de pagamento</p>
           <p>Copie e cole o código abaixo no app da sua instituição financeira para finalizar a compra.</p>
           <p class="font-semibold">Valor do pagamento</p>


### PR DESCRIPTION
## Summary
- enlarge Pix payment logo ~10% for `PagamentoPlus` view

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456e895890832090dbee21e436f12f