### PR TITLE
Show time line only within working hours

### DIFF
--- a/src/components/WeekView.vue
+++ b/src/components/WeekView.vue
@@ -96,7 +96,16 @@ export default {
     },
     showCurrentLine() {
       const totalHeight = this.timeSlots.length * 64
-      return this.currentLineTop >= 0 && this.currentLineTop <= totalHeight
+      const now = new Date()
+      const nowMinutes = now.getHours() * 60 + now.getMinutes()
+      const [startHour, startMin] = this.startTime.split(':').map(Number)
+      const [endHour, endMin] = this.endTime.split(':').map(Number)
+      const startMinutes = startHour * 60 + startMin
+      const endMinutes = endHour * 60 + endMin
+      const withinHours = nowMinutes >= startMinutes && nowMinutes <= endMinutes
+      const withinGrid =
+        this.currentLineTop >= 0 && this.currentLineTop <= totalHeight
+      return withinHours && withinGrid
     }
   },
   methods: {


### PR DESCRIPTION
## Summary
- adjust `WeekView` to hide the current time indicator outside of configured working hours

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684570ef74888320a9f3c959dc5f5d32