### PR TITLE
Adiciona botão de início no menu suspenso

### DIFF
--- a/src/components/HeaderUser.vue
+++ b/src/components/HeaderUser.vue
@@ -13,6 +13,7 @@
         </svg>
       </button>
       <div v-if="showMenu" class="absolute right-0 mt-2 w-48 bg-white border rounded shadow-md">
+        <router-link to="/" class="block px-4 py-2 hover:bg-gray-100">Início</router-link>
         <router-link to="/configuracao" class="block px-4 py-2 hover:bg-gray-100">Perfil</router-link>
         <router-link to="/usuarios" class="block px-4 py-2 hover:bg-gray-100">Usuários</router-link>
         <router-link to="/minha-assinatura" class="block px-4 py-2 hover:bg-gray-100">Assinatura</router-link>


### PR DESCRIPTION
## Summary
- add "Início" option in `HeaderUser` dropdown menu

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d5bddc1448320858245871f708fe3