### PR TITLE
Fix mobile menu not closing on navigation

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -43,6 +43,12 @@ export default {
   beforeUnmount() {
     window.removeEventListener('scroll', this.handleScroll)
   },
+  watch: {
+    // fecha o menu automaticamente ao navegar para outra rota
+    $route() {
+      this.open = false
+    }
+  },
   methods: {
     toggleMenu() {
       this.open = !this.open


### PR DESCRIPTION
## Summary
- ensure Navbar closes the mobile menu after navigating to another route

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d5f413edc8320a44f1b17ae4f0fc0