### PR TITLE
Improve mobile sidebar handling

### DIFF
--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -234,7 +234,7 @@ export default {
       sortColumn: '',
       sortAsc: true,
       showViewDropdown: false,
-      sidebarOpen: true
+      sidebarOpen: window.innerWidth >= 768
     }
   },
   computed: {

--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -143,7 +143,7 @@ export default {
         phone: ''
       },
       clients: [],
-      sidebarOpen: true,
+      sidebarOpen: window.innerWidth >= 768,
       page: 1,
       pageSize: 10
     }

--- a/src/views/Comprovantes.vue
+++ b/src/views/Comprovantes.vue
@@ -101,7 +101,7 @@ export default {
   data() {
     return {
       userId: null,
-      sidebarOpen: true,
+      sidebarOpen: window.innerWidth >= 768,
       templates: [],
       receipts: [],
       clients: [],

--- a/src/views/Configuracao.vue
+++ b/src/views/Configuracao.vue
@@ -155,7 +155,7 @@
     data() {
       return {
         userId: null,
-        sidebarOpen: true,
+        sidebarOpen: window.innerWidth >= 768,
         slug: '',
         activeTab: 'perfil',
         form: {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -188,7 +188,7 @@ export default {
       clients: [],
       services: [],
       topClients: [],
-      sidebarOpen: true,
+      sidebarOpen: window.innerWidth >= 768,
       showClientModal: false,
       showAppointmentModal: false,
       showDetailsModal: false,

--- a/src/views/Faturamento.vue
+++ b/src/views/Faturamento.vue
@@ -89,7 +89,7 @@ export default {
   data() {
     return {
       userId: null,
-      sidebarOpen: true,
+      sidebarOpen: window.innerWidth >= 768,
       services: [],
       selectedServices: [],
       filterStart: '',

--- a/src/views/MinhaAssinatura.vue
+++ b/src/views/MinhaAssinatura.vue
@@ -54,7 +54,7 @@ export default {
   components: { Sidebar, HeaderUser },
   data() {
     return {
-      sidebarOpen: true
+      sidebarOpen: window.innerWidth >= 768
     }
   },
   methods: {

--- a/src/views/PagamentoPlus.vue
+++ b/src/views/PagamentoPlus.vue
@@ -119,7 +119,7 @@ export default {
   components: { Sidebar, HeaderUser },
   data() {
     return {
-      sidebarOpen: true,
+      sidebarOpen: window.innerWidth >= 768,
       activeTab: 'cartao',
       card: {
         name: '',

--- a/src/views/Salas.vue
+++ b/src/views/Salas.vue
@@ -116,7 +116,7 @@ export default {
         name: ''
       },
       rooms: [],
-      sidebarOpen: true,
+      sidebarOpen: window.innerWidth >= 768,
       page: 1,
       pageSize: 10
     }

--- a/src/views/Servicos.vue
+++ b/src/views/Servicos.vue
@@ -137,7 +137,7 @@ export default {
       showModal: false,
       editingId: null,
       search: '',
-      sidebarOpen: true,
+      sidebarOpen: window.innerWidth >= 768,
       form: {
         name: '',
         description: '',

--- a/src/views/Templates.vue
+++ b/src/views/Templates.vue
@@ -69,7 +69,7 @@ export default {
   data() {
     return {
       userId: null,
-      sidebarOpen: true,
+      sidebarOpen: window.innerWidth >= 768,
       templates: [],
       showTemplateModal: false,
       templateForm: { name: '', content: '' }

--- a/src/views/Usuarios.vue
+++ b/src/views/Usuarios.vue
@@ -77,7 +77,7 @@ export default {
         email: '',
         password: ''
       },
-      sidebarOpen: true,
+      sidebarOpen: window.innerWidth >= 768,
       userId: null,
       successMessage: '',
       errorMessage: '',


### PR DESCRIPTION
## Summary
- hide sidebar by default on small screens across multiple views

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684d60787988832098ee94b4380e8bb0