### PR TITLE
Fix WeekView comma issue

### DIFF
--- a/src/components/WeekView.vue
+++ b/src/components/WeekView.vue
@@ -84,7 +84,7 @@ export default {
       startTime: '00:00',
       endTime: '23:00',
       dailySchedule: null,
-      timeSlots: []
+      timeSlots: [],
       currentLineTop: 0,
       lineInterval: null
     }


### PR DESCRIPTION
## Summary
- fix missing comma in WeekView.vue data object

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e1e658e10832087af34a015982d4c