### PR TITLE
Update Google Meet link generation

### DIFF
--- a/src/views/Salas.vue
+++ b/src/views/Salas.vue
@@ -145,8 +145,13 @@ export default {
       this.showModal = true
     },
     generateMeetLink() {
-      this.form.googleMeetLink = 'https://meet.google.com/new'
-      window.open(this.form.googleMeetLink, '_blank')
+      const letters = 'abcdefghijklmnopqrstuvwxyz'
+      const random = length =>
+        Array.from({ length }, () =>
+          letters[Math.floor(Math.random() * letters.length)]
+        ).join('')
+      const code = `${random(3)}-${random(4)}-${random(3)}`
+      this.form.googleMeetLink = `https://meet.google.com/${code}`
     },
     closeModal() {
       this.showModal = false


### PR DESCRIPTION
## Summary
- stop opening new Google Meet rooms when generating a link
- generate a random code for new Meet links

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e27aea16483208aa222053df7d1c9