### PR TITLE
Remove outdated popup alert

### DIFF
--- a/src/views/Salas.vue
+++ b/src/views/Salas.vue
@@ -154,7 +154,8 @@ export default {
         try {
           this.form.googleMeetLink = meetWindow.location.href
         } catch (e) {
-          alert('Copie o link criado na nova aba do Google Meet e cole no campo.')
+          // If we can't access the new window's URL due to browser
+          // restrictions, the user will need to copy it manually.
         }
       }, 3000)
     },


### PR DESCRIPTION
## Summary
- remove alert that instructed to copy Google Meet link manually

## Testing
- `npm install` *(fails: registry access blocked)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e303c64e883208aa0487fc87c8423