### PR TITLE
Implement email notification for new appointments

### DIFF
--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -1,0 +1,10 @@
+import { supabase } from '../supabase'
+
+export async function sendAppointmentEmail(details) {
+  const { error } = await supabase.functions.invoke('send-appointment-email', {
+    body: details
+  })
+  if (error) {
+    console.error('Erro ao enviar email de agendamento:', error.message)
+  }
+}

--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -219,6 +219,7 @@ import Modal from '../components/Modal.vue'
 import CalendarView from '../components/CalendarView.vue'
 import WeekView from '../components/WeekView.vue'
 import { supabase } from '../supabase'
+import { sendAppointmentEmail } from '../utils/email'
 
 export default {
   name: 'Agendamentos',
@@ -400,6 +401,14 @@ export default {
           alert('Erro ao salvar agendamento: ' + error.message)
         } else {
           this.appointments.push(data)
+          const client = this.clients.find(c => c.id === this.form.clientId)
+          const service = this.services.find(s => s.id === this.form.serviceId)
+          const room = this.rooms.find(r => r.id === this.form.roomId)
+          await sendAppointmentEmail({
+            to: client?.email,
+            subject: `Agendamento confirmado para ${this.form.date} às ${this.form.time}`,
+            text: `Olá ${client?.name},\n\nSeu agendamento para ${service?.name} foi confirmado para ${this.form.date} às ${this.form.time}.\n${room ? `Sala: ${room.name}\n` : ''}${room?.google_meet_link ? `Link: ${room.google_meet_link}\n` : ''}${this.form.description ? `Observações: ${this.form.description}` : ''}`
+          })
           this.closeModal()
         }
       }
@@ -424,6 +433,10 @@ export default {
     getClientName(clientId) {
       const client = this.clients.find(c => c.id === clientId)
       return client ? client.name : ''
+    },
+    getClientEmail(clientId) {
+      const client = this.clients.find(c => c.id === clientId)
+      return client ? client.email : ''
     },
     getServiceName(serviceId) {
       const service = this.services.find(s => s.id === serviceId)

--- a/supabase/functions/send-appointment-email/index.ts
+++ b/supabase/functions/send-appointment-email/index.ts
@@ -1,0 +1,28 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+
+serve(async req => {
+  const { to, subject, text } = await req.json()
+
+  const apiKey = Deno.env.get('RESEND_API_KEY')
+  const resp = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      from: 'no-reply@agenda-zen.com',
+      to,
+      subject,
+      text
+    })
+  })
+
+  if (!resp.ok) {
+    const err = await resp.text()
+    console.error(err)
+    return new Response('Erro ao enviar e-mail', { status: 500 })
+  }
+
+  return new Response('OK')
+})


### PR DESCRIPTION
## Summary
- add utility to invoke supabase edge function for emails
- create `send-appointment-email` edge function
- send confirmation email after saving a new appointment

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e32385154832092b3dabb2216349c