### PR TITLE
Fix CORS for confirmation email

### DIFF
--- a/supabase/functions/send-appointment-email/index.ts
+++ b/supabase/functions/send-appointment-email/index.ts
@@ -1,6 +1,17 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers':
+    'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS'
+}
+
 serve(async req => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
   const { to, subject, text } = await req.json()
 
   const apiKey = Deno.env.get('RESEND_API_KEY')
@@ -21,8 +32,8 @@ serve(async req => {
   if (!resp.ok) {
     const err = await resp.text()
     console.error(err)
-    return new Response('Erro ao enviar e-mail', { status: 500 })
+    return new Response('Erro ao enviar e-mail', { status: 500, headers: corsHeaders })
   }
 
-  return new Response('OK')
+  return new Response('OK', { headers: corsHeaders })
 })


### PR DESCRIPTION
## Summary
- allow CORS in `send-appointment-email` edge function

## Testing
- `npm install` *(fails: network restricted)*
- `npm run build` *(fails: vite not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684e363fe4a48320b7d248830d6aeb50