### PR TITLE
Fix CORS preflight response for email function

### DIFF
--- a/supabase/functions/send-appointment-email/index.ts
+++ b/supabase/functions/send-appointment-email/index.ts
@@ -4,12 +4,13 @@ const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers':
     'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS'
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Max-Age': '86400'
 }
 
 serve(async req => {
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders })
+    return new Response(null, { status: 204, headers: corsHeaders })
   }
 
   const { to, subject, text } = await req.json()


### PR DESCRIPTION
## Summary
- handle CORS preflight with 204 No Content
- add `Access-Control-Max-Age` header to cache preflight requests

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e99e2496083208f5c264b5cd8438a