### PR TITLE
Fix CORS preflight for email function

### DIFF
--- a/supabase/functions/send-appointment-email/index.ts
+++ b/supabase/functions/send-appointment-email/index.ts
@@ -10,7 +10,8 @@ const corsHeaders = {
 
 serve(async req => {
   if (req.method === 'OPTIONS') {
-    return new Response(null, { status: 204, headers: corsHeaders })
+    // Return a 200 response for CORS preflight requests
+    return new Response('ok', { status: 200, headers: corsHeaders })
   }
 
   const { to, subject, text } = await req.json()


### PR DESCRIPTION
## Summary
- modify send-appointment-email Edge Function to respond 200 to OPTIONS

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e9c6867608320a905495001d29421