### PR TITLE
Fix email sender domain

### DIFF
--- a/supabase/functions/send-appointment-email/index.ts
+++ b/supabase/functions/send-appointment-email/index.ts
@@ -24,7 +24,7 @@ serve(async req => {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({
-      from: 'no-reply@agenda-zen.com',
+      from: 'no-reply@agendazen.com.br',
       to,
       subject,
       text


### PR DESCRIPTION
## Summary
- update sender email in send-appointment-email function

## Testing
- `grep -R "agenda-zen.com" -n`

------
https://chatgpt.com/codex/tasks/task_e_684efb04d6688320a34fc18267fdcf8f