### PR TITLE
Add fields to client registration

### DIFF
--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -112,6 +112,18 @@
               @input="form.phone = phoneMask(form.phone)"
               class="w-full mt-1 px-4 py-2 border rounded-md" />
           </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Data de nascimento</label>
+            <input type="date" v-model="form.birthdate" class="w-full mt-1 px-4 py-2 border rounded-md" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">CPF</label>
+            <input type="text" v-model="form.cpf" class="w-full mt-1 px-4 py-2 border rounded-md" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Endereço completo</label>
+            <input type="text" v-model="form.address" class="w-full mt-1 px-4 py-2 border rounded-md" />
+          </div>
           <div class="flex justify-end space-x-2">
             <button type="button" @click="closeModal" class="px-4 py-2 rounded border">Cancelar</button>
             <button type="submit" class="btn">Salvar</button>
@@ -133,19 +145,22 @@ export default {
   name: 'Clientes',
   components: { Sidebar, HeaderUser, Modal },
   data() {
-    return {
-      userId: null,
-      showModal: false,
-      search: '',
-      form: {
-        name: '',
-        email: '',
-        phone: ''
-      },
-      clients: [],
-      sidebarOpen: window.innerWidth >= 768,
-      page: 1,
-      pageSize: 10
+      return {
+        userId: null,
+        showModal: false,
+        search: '',
+        form: {
+          name: '',
+          email: '',
+          phone: '',
+          birthdate: '',
+          cpf: '',
+          address: ''
+        },
+        clients: [],
+        sidebarOpen: window.innerWidth >= 768,
+        page: 1,
+        pageSize: 10
     }
   },
   methods: {
@@ -156,7 +171,7 @@ export default {
     },
     closeModal() {
       this.showModal = false
-      this.form = { name: '', email: '', phone: '' }
+      this.form = { name: '', email: '', phone: '', birthdate: '', cpf: '', address: '' }
     },
     whatsappLink(phone) {
       const formatted = digitsOnly(phone)
@@ -169,6 +184,9 @@ export default {
           name: this.form.name,
           email: this.form.email,
           phone: this.form.phone,
+          birthdate: this.form.birthdate,
+          cpf: this.form.cpf,
+          address: this.form.address,
           user_id: this.userId
         })
         .select()

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -98,6 +98,18 @@
               @input="clientForm.phone = phoneMask(clientForm.phone)"
               class="w-full mt-1 px-4 py-2 border rounded-md" />
           </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Data de nascimento</label>
+            <input type="date" v-model="clientForm.birthdate" class="w-full mt-1 px-4 py-2 border rounded-md" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">CPF</label>
+            <input type="text" v-model="clientForm.cpf" class="w-full mt-1 px-4 py-2 border rounded-md" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Endereço completo</label>
+            <input type="text" v-model="clientForm.address" class="w-full mt-1 px-4 py-2 border rounded-md" />
+          </div>
           <div class="flex justify-end space-x-2">
             <button type="button" @click="showClientModal = false" class="px-4 py-2 rounded border">Cancelar</button>
             <button type="submit" class="bg-green-600 text-white px-6 py-2 rounded-lg hover:bg-green-700">Salvar</button>
@@ -197,7 +209,10 @@ export default {
       clientForm: {
         name: '',
         email: '',
-        phone: ''
+        phone: '',
+        birthdate: '',
+        cpf: '',
+        address: ''
       },
       appointmentForm: {
         date: '',
@@ -370,6 +385,9 @@ export default {
           name: this.clientForm.name,
           email: this.clientForm.email,
           phone: this.clientForm.phone,
+          birthdate: this.clientForm.birthdate,
+          cpf: this.clientForm.cpf,
+          address: this.clientForm.address,
           user_id: this.userId
         })
         .select()
@@ -379,7 +397,7 @@ export default {
         alert('Erro ao salvar cliente: ' + error.message)
       } else {
         this.clients.push(data)
-        this.clientForm = { name: '', email: '', phone: '' }
+        this.clientForm = { name: '', email: '', phone: '', birthdate: '', cpf: '', address: '' }
         this.stats.clients += 1
         const now = new Date(data.created_at)
         const startMonth = new Date(now.getFullYear(), now.getMonth(), 1)

--- a/supabase/schemas/002_create_clients.sql
+++ b/supabase/schemas/002_create_clients.sql
@@ -4,6 +4,9 @@ create table if not exists clients (
   name text not null,
   email text,
   phone text,
+  birthdate date,
+  cpf text,
+  address text,
   created_at timestamp with time zone default now()
 );
 

--- a/supabase/schemas/015_add_fields_to_clients.sql
+++ b/supabase/schemas/015_add_fields_to_clients.sql
@@ -1,0 +1,3 @@
+alter table clients add column if not exists birthdate date;
+alter table clients add column if not exists cpf text;
+alter table clients add column if not exists address text;


### PR DESCRIPTION
## Summary
- extend client registration with birthdate, CPF and address
- update schema to include the new columns

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852a935ea608320a0fffd580c493a7a