### PR TITLE
Improve client modal responsiveness

### DIFF
--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" @click.self="$emit('close')">
-    <div class="bg-white p-6 rounded-lg shadow-lg w-full max-w-lg">
+    <div class="bg-white p-6 rounded-lg shadow-lg w-full max-w-lg md:max-w-2xl max-h-[90vh] overflow-y-auto">
       <slot></slot>
     </div>
   </div>

--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -93,9 +93,9 @@
       </div>
       </section>
 
-      <Modal v-if="showModal" @close="closeModal">
-        <h3 class="text-lg font-semibold mb-4">Adicionar Cliente</h3>
-        <form @submit.prevent="handleAddClient" class="space-y-6">
+        <Modal v-if="showModal" @close="closeModal">
+          <h3 class="text-lg font-semibold mb-4">Adicionar Cliente</h3>
+          <form @submit.prevent="handleAddClient" class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label class="block text-sm font-medium text-gray-700">Nome</label>
             <input type="text" v-model="form.name" class="w-full mt-1 px-4 py-2 border rounded-md" />
@@ -154,7 +154,7 @@
               <option v-for="c in cities" :key="c.id" :value="c.id">{{ c.nome }}</option>
             </select>
           </div>
-          <div class="flex justify-end space-x-2">
+            <div class="flex justify-end space-x-2 md:col-span-2">
             <button type="button" @click="closeModal" class="px-4 py-2 rounded border">Cancelar</button>
             <button type="submit" class="btn">Salvar</button>
           </div>


### PR DESCRIPTION
## Summary
- allow modal to scroll when content exceeds viewport
- arrange the customer form in a responsive grid

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b08b878883209d6aaab3a2e98e75