### PR TITLE
Fix null state access in location script

### DIFF
--- a/supabase/scripts/generate_locations_sql.js
+++ b/supabase/scripts/generate_locations_sql.js
@@ -27,9 +27,14 @@ async function main() {
   const cities = await fetchJSON('https://servicodados.ibge.gov.br/api/v1/localidades/municipios');
   const citySql = cities
     .map(c => {
-      const stateId = c.microrregiao.mesorregiao.UF.id;
+      const stateId = c.microrregiao?.mesorregiao?.UF?.id;
+      if (!stateId) {
+        console.warn(`State id not found for city ${c.nome} (${c.id}), skipping.`);
+        return null;
+      }
       return `insert into cities (id, state_id, name) values (${c.id}, ${stateId}, '${escape(c.nome)}');`;
     })
+    .filter(Boolean)
     .join('\n');
   fs.writeFileSync('brazil_cities.sql', citySql);
 }


### PR DESCRIPTION
## Summary
- guard access to `microrregiao.mesorregiao.UF.id`
- skip any city record without state info

## Testing
- `node supabase/scripts/generate_locations_sql.js` *(fails: ENETUNREACH)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b1eb5760832083b5cc3d1ec453e6