### PR TITLE
Adjust client field order

### DIFF
--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -101,6 +101,14 @@
             <input type="text" v-model="form.name" class="w-full mt-1 px-4 py-2 border rounded-md" />
           </div>
           <div>
+            <label class="block text-sm font-medium text-gray-700">CPF</label>
+            <input type="text" v-model="form.cpf" class="w-full mt-1 px-4 py-2 border rounded-md" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Data de nascimento</label>
+            <input type="date" v-model="form.birthdate" class="w-full mt-1 px-4 py-2 border rounded-md" />
+          </div>
+          <div>
             <label class="block text-sm font-medium text-gray-700">E-mail</label>
             <input type="email" v-model="form.email" class="w-full mt-1 px-4 py-2 border rounded-md" />
           </div>
@@ -111,14 +119,6 @@
               v-model="form.phone"
               @input="form.phone = phoneMask(form.phone)"
               class="w-full mt-1 px-4 py-2 border rounded-md" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Data de nascimento</label>
-            <input type="date" v-model="form.birthdate" class="w-full mt-1 px-4 py-2 border rounded-md" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">CPF</label>
-            <input type="text" v-model="form.cpf" class="w-full mt-1 px-4 py-2 border rounded-md" />
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">CEP</label>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -87,6 +87,14 @@
             <input type="text" v-model="clientForm.name" class="w-full mt-1 px-4 py-2 border rounded-md" />
           </div>
           <div>
+            <label class="block text-sm font-medium text-gray-700">CPF</label>
+            <input type="text" v-model="clientForm.cpf" class="w-full mt-1 px-4 py-2 border rounded-md" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Data de nascimento</label>
+            <input type="date" v-model="clientForm.birthdate" class="w-full mt-1 px-4 py-2 border rounded-md" />
+          </div>
+          <div>
             <label class="block text-sm font-medium text-gray-700">E-mail</label>
             <input type="email" v-model="clientForm.email" class="w-full mt-1 px-4 py-2 border rounded-md" />
           </div>
@@ -97,14 +105,6 @@
               v-model="clientForm.phone"
               @input="clientForm.phone = phoneMask(clientForm.phone)"
               class="w-full mt-1 px-4 py-2 border rounded-md" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Data de nascimento</label>
-            <input type="date" v-model="clientForm.birthdate" class="w-full mt-1 px-4 py-2 border rounded-md" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">CPF</label>
-            <input type="text" v-model="clientForm.cpf" class="w-full mt-1 px-4 py-2 border rounded-md" />
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">CEP</label>


### PR DESCRIPTION
## Summary
- reorder fields in client forms to match requested order

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b3c9bab08320abc83d6885137e1e