### PR TITLE
Adiciona máscaras e validação de e-mail

### DIFF
--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,0 +1,24 @@
+export function cpfMask(value) {
+  const digits = value.replace(/\D/g, '').slice(0, 11)
+  const part1 = digits.slice(0, 3)
+  const part2 = digits.slice(3, 6)
+  const part3 = digits.slice(6, 9)
+  const part4 = digits.slice(9, 11)
+  if (digits.length <= 3) return digits
+  if (digits.length <= 6) return `${part1}.${digits.slice(3)}`
+  if (digits.length <= 9) return `${part1}.${part2}.${digits.slice(6)}`
+  return `${part1}.${part2}.${part3}-${part4}`
+}
+
+export function cepMask(value) {
+  const digits = value.replace(/\D/g, '').slice(0, 8)
+  const part1 = digits.slice(0, 5)
+  const part2 = digits.slice(5)
+  if (digits.length <= 5) return digits
+  return `${part1}-${part2}`
+}
+
+export function isValidEmail(email) {
+  const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  return regex.test(email)
+}

--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -102,7 +102,11 @@
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">CPF</label>
-            <input type="text" v-model="form.cpf" class="w-full mt-1 px-4 py-2 border rounded-md" />
+          <input
+            type="text"
+            v-model="form.cpf"
+            @input="form.cpf = cpfMask(form.cpf)"
+            class="w-full mt-1 px-4 py-2 border rounded-md" />
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">Data de nascimento</label>
@@ -122,7 +126,11 @@
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">CEP</label>
-            <input type="text" v-model="form.cep" class="w-full mt-1 px-4 py-2 border rounded-md" />
+          <input
+            type="text"
+            v-model="form.cep"
+            @input="form.cep = cepMask(form.cep)"
+            class="w-full mt-1 px-4 py-2 border rounded-md" />
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">Endereço</label>
@@ -171,6 +179,7 @@ import Modal from '../components/Modal.vue'
 import { supabase } from '../supabase'
 import { phoneMask, digitsOnly } from '../utils/phone'
 import { fetchStates, fetchCities } from '../utils/locations'
+import { cpfMask, cepMask, isValidEmail } from '../utils/format'
 
 export default {
   name: 'Clientes',
@@ -205,6 +214,8 @@ export default {
   methods: {
     phoneMask,
     digitsOnly,
+    cpfMask,
+    cepMask,
     async fetchStatesList() {
       this.states = await fetchStates()
     },
@@ -239,7 +250,11 @@ export default {
       const formatted = digitsOnly(phone)
       return `https://wa.me/${formatted}`
     },
-    async handleAddClient() {
+   async handleAddClient() {
+      if (this.form.email && !isValidEmail(this.form.email)) {
+        alert('E-mail inválido')
+        return
+      }
       const { data, error } = await supabase
         .from('clients')
         .insert({

--- a/src/views/Configuracao.vue
+++ b/src/views/Configuracao.vue
@@ -142,7 +142,8 @@
   import Sidebar from '../components/Sidebar.vue'
   import HeaderUser from '../components/HeaderUser.vue'
   import { supabase } from '../supabase'
-  import { phoneMask } from '../utils/phone'
+import { phoneMask } from '../utils/phone'
+import { isValidEmail } from '../utils/format'
   
   export default {
     name: 'Configuracao',
@@ -200,6 +201,10 @@
           .replace(/(^-|-$)/g, '')
       },
       async handleSave() {
+        if (this.form.email && !isValidEmail(this.form.email)) {
+          alert('E-mail inválido')
+          return
+        }
         const updates = {
           id: this.userId,
           business_name: this.form.businessName,

--- a/src/views/Contato.vue
+++ b/src/views/Contato.vue
@@ -43,6 +43,7 @@
 import Navbar from '../components/Navbar.vue'
 import Footer from '../components/Footer.vue'
 import { supabase } from '../supabase'
+import { isValidEmail } from '../utils/format'
 
 export default {
   name: 'Contato',
@@ -60,6 +61,10 @@ export default {
     async enviar() {
       this.sucesso = false
       this.erro = ''
+      if (this.email && !isValidEmail(this.email)) {
+        this.erro = 'E-mail inválido'
+        return
+      }
       const { error } = await supabase.from('contacts').insert({
         name: this.nome,
         email: this.email,

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -88,7 +88,11 @@
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">CPF</label>
-            <input type="text" v-model="clientForm.cpf" class="w-full mt-1 px-4 py-2 border rounded-md" />
+            <input
+              type="text"
+              v-model="clientForm.cpf"
+              @input="clientForm.cpf = cpfMask(clientForm.cpf)"
+              class="w-full mt-1 px-4 py-2 border rounded-md" />
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">Data de nascimento</label>
@@ -108,7 +112,11 @@
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">CEP</label>
-            <input type="text" v-model="clientForm.cep" class="w-full mt-1 px-4 py-2 border rounded-md" />
+            <input
+              type="text"
+              v-model="clientForm.cep"
+              @input="clientForm.cep = cepMask(clientForm.cep)"
+              class="w-full mt-1 px-4 py-2 border rounded-md" />
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">Endereço</label>
@@ -214,6 +222,7 @@ import { supabase } from '../supabase'
 import { Chart } from 'chart.js/auto'
 import { phoneMask } from '../utils/phone'
 import { fetchStates, fetchCities } from '../utils/locations'
+import { cpfMask, cepMask, isValidEmail } from '../utils/format'
 
 export default {
   name: 'Dashboard',
@@ -266,6 +275,8 @@ export default {
   },
   methods: {
     phoneMask,
+    cpfMask,
+    cepMask,
     async fetchStatesList() {
       this.states = await fetchStates()
     },
@@ -430,7 +441,11 @@ export default {
         this.showDetailsModal = false
         this.selectedAppointment = null
       },
-    async handleAddClient() {
+  async handleAddClient() {
+      if (this.clientForm.email && !isValidEmail(this.clientForm.email)) {
+        alert('E-mail inválido')
+        return
+      }
       const { data, error } = await supabase
         .from('clients')
         .insert({

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -30,6 +30,7 @@
 import Navbar from '../components/Navbar.vue'
 import Footer from '../components/Footer.vue'
 import { supabase } from '../supabase'
+import { isValidEmail } from '../utils/format'
 
 export default {
   name: 'Login',
@@ -42,6 +43,10 @@ export default {
     },
     methods: {
       async handleLogin() {
+        if (this.email && !isValidEmail(this.email)) {
+          alert('E-mail inválido')
+          return
+        }
         const { data, error } = await supabase.auth.signInWithPassword({
           email: this.email,
           password: this.password

--- a/src/views/Onboarding.vue
+++ b/src/views/Onboarding.vue
@@ -88,6 +88,7 @@
 <script>
 import { supabase } from '../supabase'
 import { phoneMask } from '../utils/phone'
+import { isValidEmail } from '../utils/format'
 
 export default {
   name: 'Onboarding',
@@ -140,6 +141,10 @@ export default {
       if (this.step > 1) this.step--
     },
     async saveProfile() {
+      if (this.form.email && !isValidEmail(this.form.email)) {
+        alert('E-mail inválido')
+        return
+      }
       const updates = {
         id: this.userId,
         business_name: this.form.businessName,

--- a/src/views/Signup.vue
+++ b/src/views/Signup.vue
@@ -29,6 +29,7 @@
 import Navbar from '../components/Navbar.vue'
 import Footer from '../components/Footer.vue'
 import { supabase } from '../supabase'
+import { isValidEmail } from '../utils/format'
 
 export default {
   name: 'Signup',
@@ -41,6 +42,10 @@ export default {
   },
   methods: {
     async handleSignup() {
+      if (this.email && !isValidEmail(this.email)) {
+        alert('E-mail inválido')
+        return
+      }
       const { data, error } = await supabase.auth.signUp({
         email: this.email,
         password: this.password

--- a/src/views/Usuarios.vue
+++ b/src/views/Usuarios.vue
@@ -67,6 +67,7 @@
 import Sidebar from '../components/Sidebar.vue'
 import HeaderUser from '../components/HeaderUser.vue'
 import { supabase } from '../supabase'
+import { isValidEmail } from '../utils/format'
 
 export default {
   name: 'Usuarios',
@@ -89,6 +90,11 @@ export default {
     async handleAddUser() {
       this.successMessage = ''
       this.errorMessage = ''
+
+      if (this.form.email && !isValidEmail(this.form.email)) {
+        this.errorMessage = 'E-mail inválido'
+        return
+      }
 
       const { data: { user: currentUser } } = await supabase.auth.getUser()
       const { data: { session: currentSession } } = await supabase.auth.getSession()


### PR DESCRIPTION
## Summary
- create new `format.js` utils with CPF/CEP masks and email validator
- aplly máscaras de CPF e CEP nos formulários de cliente
- validar formato de e-mail antes de salvar dados

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852dc33142483209d3dd4b41d144e48