### PR TITLE
Implement display name on sign up

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Agenda Zen é uma aplicação web de agendamento para psicólogos, terapeutas e 
 ## Principais funcionalidades
 
 - Cadastro e autenticação de usuários
+- Nome cadastrado é salvo como display name no Supabase
 - Gestão de clientes, serviços e salas
 - Controle de agendamentos em lista, calendário ou semana
 - Dashboard com estatísticas e gráficos (Chart.js)

--- a/src/views/Signup.vue
+++ b/src/views/Signup.vue
@@ -59,7 +59,7 @@ export default {
         email: this.email,
         password: this.password,
         options: {
-          data: { name: this.name }
+          data: { name: this.name, display_name: this.name }
         }
       })
 


### PR DESCRIPTION
## Summary
- save user's name as display_name on sign up
- document display_name in README

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852e38c94048320ae41e4cf5345a9e4