### PR TITLE
Add signup confirmation page

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -22,11 +22,13 @@ import Faq from '../views/Faq.vue'
 import PoliticaPrivacidade from '../views/PoliticaPrivacidade.vue'
 import TermosDeUso from '../views/TermosDeUso.vue'
 import PagamentoPlus from '../views/PagamentoPlus.vue'
+import Confirmacao from '../views/Confirmacao.vue'
 
 
 const routes = [
   { path: '/', name: 'Home', component: Home },
   { path: '/cadastro', name: 'Signup', component: Signup },
+  { path: '/confirmacao', name: 'Confirmacao', component: Confirmacao },
   { path: '/login', name: 'Login', component: Login },
   { path: '/onboarding', name: 'Onboarding', component: Onboarding },
   { path: '/dashboard', name: 'Dashboard', component: Dashboard },

--- a/src/views/Confirmacao.vue
+++ b/src/views/Confirmacao.vue
@@ -1,0 +1,21 @@
+<template>
+  <Navbar />
+  <section class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-blue-100 px-4">
+    <div class="bg-white p-10 rounded-2xl shadow-xl w-full max-w-lg text-center space-y-6">
+      <img src="/icons/check.svg" alt="Sucesso" class="w-16 h-16 mx-auto text-green-500" />
+      <h1 class="text-2xl font-bold text-green-600">Cadastro efetuado com sucesso</h1>
+      <router-link to="/" class="btn inline-block">Início</router-link>
+    </div>
+  </section>
+  <Footer />
+</template>
+
+<script>
+import Navbar from '../components/Navbar.vue'
+import Footer from '../components/Footer.vue'
+
+export default {
+  name: 'Confirmacao',
+  components: { Navbar, Footer }
+}
+</script>


### PR DESCRIPTION
## Summary
- add a confirmation view
- register the page route in the router

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6852ebf30f8483209a1e76f6e54185f8