### PR TITLE
Fix email confirmation redirect

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,5 +2,17 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
 import './assets/main.css'
+import { supabase } from './supabase'
+
+// Redireciona para a página de confirmação após validar o e-mail
+supabase.auth.onAuthStateChange((event) => {
+  if (
+    event === 'SIGNED_IN' &&
+    window.location.hash.includes('access_token') &&
+    window.location.hash.includes('type=signup')
+  ) {
+    router.replace('/confirmacao')
+  }
+})
 
 createApp(App).use(router).mount('#app')


### PR DESCRIPTION
## Summary
- handle Supabase sign‑up return and redirect to the confirmation view

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853151d21d08320811363eee3ae4547