### PR TITLE
Add login error message

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -17,6 +17,13 @@
           </div>
           <button type="submit" class="btn w-full">Entrar</button>
           <button type="button" @click="handleGoogleLogin" class="w-full bg-red-500 text-white font-semibold py-3 rounded-lg hover:bg-red-600 transition duration-200">Entrar com Google</button>
+          <p v-if="loginError" class="text-red-600 text-center text-sm">
+            {{ loginError }}
+            <template v-if="loginError === 'E-mail ou senha inválidos'">
+              Caso não possua cadastro,
+              <router-link to="/cadastro" class="text-blue-600 underline">clique aqui para se cadastrar</router-link>.
+            </template>
+          </p>
         </form>
         <p class="mt-6 text-center text-sm text-gray-500">
           Ainda não tem conta? <router-link to="/cadastro" class="text-blue-600 hover:underline">Criar agora</router-link>
@@ -38,22 +45,24 @@ export default {
   data() {
       return {
         email: '',
-        password: ''
+        password: '',
+        loginError: ''
       }
     },
     methods: {
       async handleLogin() {
+        this.loginError = ''
         if (this.email && !isValidEmail(this.email)) {
-          alert('E-mail inválido')
+          this.loginError = 'E-mail inválido'
           return
         }
-        const { data, error } = await supabase.auth.signInWithPassword({
+        const { error } = await supabase.auth.signInWithPassword({
           email: this.email,
           password: this.password
         })
 
         if (error) {
-            alert('Erro ao entrar: ' + error.message)
+            this.loginError = 'E-mail ou senha inválidos'
         } else {
             this.$router.push('/dashboard')
         }


### PR DESCRIPTION
## Summary
- add loginError state to Login page
- show error message for invalid login and link to sign up

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853eaefea8c8320a86eaf3b5d8b65b3