### PR TITLE
Add page for expired confirmation links

### DIFF
--- a/public/icons/error.svg
+++ b/public/icons/error.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+</svg>

--- a/src/main.js
+++ b/src/main.js
@@ -4,15 +4,23 @@ import router from './router'
 import './assets/main.css'
 import { supabase } from './supabase'
 
-// Processa tokens de confirmação enviados pelo Supabase
+// Processa tokens ou erros de confirmação enviados pelo Supabase
 const handleEmailConfirmation = async () => {
+  const hash = window.location.hash.replace(/^#\/?/, '')
+  const params = new URLSearchParams(hash)
+
+  if (
+    params.get('error_code') === 'otp_expired' ||
+    params.get('error_description')?.includes('Email link is invalid')
+  ) {
+    router.replace('/link-expirado')
+    return
+  }
+
   if (
     window.location.hash.includes('access_token') &&
     window.location.hash.includes('type=signup')
   ) {
-    const hash = window.location.hash.replace(/^#\/?/, '')
-    const params = new URLSearchParams(hash)
-
     const access_token = params.get('access_token')
     const refresh_token = params.get('refresh_token')
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -23,12 +23,14 @@ import PoliticaPrivacidade from '../views/PoliticaPrivacidade.vue'
 import TermosDeUso from '../views/TermosDeUso.vue'
 import PagamentoPlus from '../views/PagamentoPlus.vue'
 import Confirmacao from '../views/Confirmacao.vue'
+import LinkExpirado from '../views/LinkExpirado.vue'
 
 
 const routes = [
   { path: '/', name: 'Home', component: Home },
   { path: '/cadastro', name: 'Signup', component: Signup },
   { path: '/confirmacao', name: 'Confirmacao', component: Confirmacao },
+  { path: '/link-expirado', name: 'LinkExpirado', component: LinkExpirado },
   { path: '/login', name: 'Login', component: Login },
   { path: '/onboarding', name: 'Onboarding', component: Onboarding },
   { path: '/dashboard', name: 'Dashboard', component: Dashboard },

--- a/src/views/LinkExpirado.vue
+++ b/src/views/LinkExpirado.vue
@@ -1,0 +1,51 @@
+<template>
+  <Navbar />
+  <section class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-blue-100 px-4">
+    <div class="bg-white p-10 rounded-2xl shadow-xl w-full max-w-lg text-center space-y-6">
+      <img src="/icons/error.svg" alt="Erro" class="w-16 h-16 mx-auto text-red-500" />
+      <h1 class="text-2xl font-bold text-red-600">Link expirado ou inválido</h1>
+      <p class="text-gray-700">Informe seu e-mail para receber um novo link de confirmação.</p>
+      <input v-model="email" type="email" placeholder="seu@email.com"
+             class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+      <div class="flex justify-center space-x-4">
+        <button @click="reenviarLink" class="btn">Reenviar link</button>
+        <router-link to="/" class="btn">Início</router-link>
+      </div>
+    </div>
+  </section>
+  <Footer />
+</template>
+
+<script>
+import Navbar from '../components/Navbar.vue'
+import Footer from '../components/Footer.vue'
+import { supabase } from '../supabase'
+import { isValidEmail } from '../utils/format'
+
+export default {
+  name: 'LinkExpirado',
+  components: { Navbar, Footer },
+  data() {
+    return {
+      email: ''
+    }
+  },
+  methods: {
+    async reenviarLink() {
+      if (!isValidEmail(this.email)) {
+        alert('E-mail inválido')
+        return
+      }
+      const { error } = await supabase.auth.resend({
+        type: 'signup',
+        email: this.email
+      })
+      if (error) {
+        alert('Erro ao reenviar link: ' + error.message)
+      } else {
+        alert('Link reenviado! Verifique seu e-mail.')
+      }
+    }
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- add `LinkExpirado` view with resend option
- route `/link-expirado`
- detect `otp_expired` error in `main.js`
- include error icon

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ebfce7c08320ae15d454baf61eab