### PR TITLE
Fix slug generation and link for public pages

### DIFF
--- a/src/views/Configuracao.vue
+++ b/src/views/Configuracao.vue
@@ -32,9 +32,9 @@
             <input type="text" v-model="form.businessName" @input="updateSlug" class="w-full mt-1 px-4 py-2 border rounded-md">
             <p class="text-sm text-gray-500 mt-1">
               Seu link público:
-              <span class="font-mono">/agenda-zen/#/{{ slug }}</span>
+              <span class="font-mono">#/{{ slug }}</span>
               <a
-                :href="'/agenda-zen/#/' + slug"
+                :href="'#/' + slug"
                 target="_blank"
                 class="text-blue-600 hover:underline ml-2"
               >Abrir página do cliente</a>

--- a/src/views/Onboarding.vue
+++ b/src/views/Onboarding.vue
@@ -125,6 +125,15 @@ export default {
   },
   methods: {
     phoneMask,
+    generateSlug(name) {
+      if (!name) return ''
+      return name
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/\p{Diacritic}/gu, '')
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/(^-|-$)/g, '')
+    },
     async next() {
       if (this.step === 1) {
         await this.saveProfile()
@@ -148,6 +157,7 @@ export default {
       const updates = {
         id: this.userId,
         business_name: this.form.businessName,
+        slug: this.generateSlug(this.form.businessName),
         phone: this.form.phone,
         email: this.form.email
       }


### PR DESCRIPTION
## Summary
- ensure onboarding generates and saves a slug for new profiles
- correct the public page URL shown in the configuration screen

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c27918188320b0893d140a256d7e