### PR TITLE
Fix dropdown overlay in weekly view

### DIFF
--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -52,7 +52,7 @@
             </button>
             <div
               v-if="showViewDropdown"
-              class="absolute right-0 mt-2 w-32 bg-white border rounded shadow"
+              class="absolute right-0 mt-2 w-32 bg-white border rounded shadow z-20"
             >
               <button
                 @click="setViewMode('list')"


### PR DESCRIPTION
## Summary
- ensure the display mode dropdown renders above the weekly calendar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856d014606083209a6b27ba159c455b