### PR TITLE
Centralize details page buttons

### DIFF
--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -131,14 +131,14 @@
               <a :href="getRoomLink(selectedAppointment.room_id)" target="_blank" class="text-blue-600 underline">Acessar Google Meet</a>
             </p>
           </div>
-            <div class="flex justify-end mt-4 space-x-2">
-              <button @click="startAppointment" class="btn btn-primary">Iniciar atendimento</button>
-              <button @click="cancelAppointment" class="btn btn-warning">Desmarcou atendimento</button>
-              <button @click="markNoShow" class="btn btn-secondary">Faltou ao atendimento</button>
-              <button @click="sendConfirmationWhatsApp" class="btn btn-success">Enviar confirmação</button>
-              <button @click="handleDeleteAppointment(selectedAppointment.id)" class="btn btn-danger">Excluir</button>
-              <button @click="editFromDetails" class="btn">Editar</button>
-              <button @click="closeDetails" class="px-4 py-2 rounded border">Fechar</button>
+          <div class="flex justify-center mt-4 space-x-2">
+            <button @click="startAppointment" class="btn btn-primary">Iniciar atendimento</button>
+            <button @click="cancelAppointment" class="btn btn-warning">Desmarcou atendimento</button>
+            <button @click="markNoShow" class="btn btn-secondary">Faltou ao atendimento</button>
+            <button @click="sendConfirmationWhatsApp" class="btn btn-success">Enviar confirmação</button>
+            <button @click="handleDeleteAppointment(selectedAppointment.id)" class="btn btn-danger">Excluir</button>
+            <button @click="editFromDetails" class="btn">Editar</button>
+            <button @click="closeDetails" class="px-4 py-2 rounded border">Fechar</button>
             </div>
           </Modal>
 

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -205,7 +205,7 @@
           <p><strong>Duração:</strong> {{ selectedAppointment.duration }}</p>
           <p><strong>Descrição:</strong> {{ selectedAppointment.description }}</p>
         </div>
-        <div class="flex justify-end mt-4 space-x-2">
+        <div class="flex justify-center mt-4 space-x-2">
           <button @click="handleDeleteAppointment(selectedAppointment.id)" class="btn btn-danger">Excluir</button>
           <button @click="closeDetails" class="px-4 py-2 rounded border">Fechar</button>
         </div>


### PR DESCRIPTION
## Summary
- center button group in Agendamentos details modal
- center button group in Dashboard details modal

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6856e152c63483208e1c6a5e8cbb9cf6