### PR TITLE
Reorder appointment detail actions

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -14,6 +14,7 @@ import PublicPage from '../views/PublicPage.vue'
 import Planos from '../views/Planos.vue'
 import Salas from '../views/Salas.vue'
 import Comprovantes from '../views/Comprovantes.vue'
+import Atendimento from '../views/Atendimento.vue'
 import Templates from '../views/Templates.vue'
 import Contato from '../views/Contato.vue'
 import MinhaAssinatura from '../views/MinhaAssinatura.vue'
@@ -51,6 +52,7 @@ const routes = [
   { path: '/faq', name: 'Faq', component: Faq },
   { path: '/politica-de-privacidade', name: 'PoliticaDePrivacidade', component: PoliticaPrivacidade },
   { path: '/termos-de-uso', name: 'TermosDeUso', component: TermosDeUso },
+  { path: '/atendimento/:id', name: 'Atendimento', component: Atendimento },
   { path: '/:slug', name: 'PublicPage', component: PublicPage },
 ]
 

--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -131,14 +131,15 @@
               <a :href="getRoomLink(selectedAppointment.room_id)" target="_blank" class="text-blue-600 underline">Acessar Google Meet</a>
             </p>
           </div>
-            <div class="flex justify-end mt-4 space-x-2">
-              <button @click="startAppointment" class="btn btn-primary">Iniciar atendimento</button>
-              <button @click="cancelAppointment" class="btn btn-warning">Desmarcou atendimento</button>
-              <button @click="markNoShow" class="btn btn-secondary">Faltou ao atendimento</button>
-              <button @click="sendConfirmationWhatsApp" class="btn btn-success">Enviar confirmação</button>
-              <button @click="handleDeleteAppointment(selectedAppointment.id)" class="btn btn-danger">Excluir</button>
-              <button @click="editFromDetails" class="btn">Editar</button>
-              <button @click="closeDetails" class="px-4 py-2 rounded border">Fechar</button>
+          <div class="flex justify-center mt-4 space-x-2">
+            <button @click="sendConfirmationWhatsApp" class="btn btn-success">Enviar confirmação</button>
+            <button @click="editFromDetails" class="btn">Editar</button>
+            <button @click="handleDeleteAppointment(selectedAppointment.id)" class="btn btn-danger">Excluir</button>
+            <button @click="cancelAppointment" class="btn btn-warning">Desmarcou atendimento</button>
+            <button @click="markNoShow" class="btn btn-secondary">Faltou ao atendimento</button>
+            <button @click="startAppointment" class="btn btn-primary">Iniciar atendimento</button>
+            <button @click="closeDetails" class="px-4 py-2 rounded border">Fechar</button>
+          </div>
             </div>
           </Modal>
 
@@ -488,13 +489,8 @@ export default {
       this.showDetailsModal = true
     },
     startAppointment() {
-      if (!this.selectedAppointment) return
-      const link = this.getRoomLink(this.selectedAppointment.room_id)
-      if (link) {
-        window.open(link, '_blank')
-      } else {
-        alert('Início do atendimento registrado.')
-      }
+        if (!this.selectedAppointment) return
+        this.$router.push(`/atendimento/${this.selectedAppointment.id}`)
     },
     async cancelAppointment() {
       if (!this.selectedAppointment) return

--- a/src/views/Atendimento.vue
+++ b/src/views/Atendimento.vue
@@ -1,0 +1,139 @@
+<template>
+  <div class="min-h-screen flex bg-gray-100 relative">
+    <Sidebar :is-open="sidebarOpen" @close="sidebarOpen = false" />
+    <main class="flex-1 p-4 md:p-8">
+      <div v-if="!sidebarOpen" class="flex items-center mb-4">
+        <button @click="sidebarOpen = true" class="text-gray-600 focus:outline-none">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+      <HeaderUser title="Atendimento" />
+      <section class="bg-white p-4 rounded-lg shadow mt-4">
+        <div class="border-b mb-4">
+          <nav class="flex space-x-4">
+            <button :class="activeTab === 'current' ? 'border-b-2 border-blue-500 pb-2' : 'text-gray-500 pb-2'" @click="activeTab = 'current'">Atendimento</button>
+            <button :class="activeTab === 'history' ? 'border-b-2 border-blue-500 pb-2' : 'text-gray-500 pb-2'" @click="activeTab = 'history'">Histórico de atendimento</button>
+          </nav>
+        </div>
+        <div v-if="activeTab === 'current'">
+          <p class="mb-2 text-sm text-gray-600">Data/hora: {{ appointmentDateTime }}</p>
+          <textarea v-model="note" class="w-full border rounded p-2 mb-4" rows="6" placeholder="Descreva o atendimento"></textarea>
+          <input type="file" multiple @change="handleFileChange" class="mb-4" />
+          <button @click="saveNote" class="btn">Salvar</button>
+        </div>
+        <div v-else>
+          <div v-for="group in groupedNotes" :key="group.date" class="mb-4">
+            <h4 class="font-semibold mb-2">{{ group.date }}</h4>
+            <div v-for="n in group.items" :key="n.id" class="border p-2 rounded mb-2">
+              <p class="text-sm text-gray-600 mb-1">{{ formatDateTime(n.created_at) }}</p>
+              <p class="mb-2 whitespace-pre-line">{{ n.note }}</p>
+              <div v-if="n.attachments && n.attachments.length" class="space-x-2">
+                <a v-for="(url, idx) in n.attachments" :key="idx" :href="url" target="_blank" class="text-blue-600 underline">Anexo {{ idx + 1 }}</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+</template>
+
+<script>
+import Sidebar from '../components/Sidebar.vue'
+import HeaderUser from '../components/HeaderUser.vue'
+import { supabase } from '../supabase'
+
+export default {
+  name: 'Atendimento',
+  components: { Sidebar, HeaderUser },
+  data() {
+    return {
+      sidebarOpen: window.innerWidth >= 768,
+      activeTab: 'current',
+      appointment: null,
+      note: '',
+      files: [] ,
+      notes: [],
+      userId: null
+    }
+  },
+  computed: {
+    appointmentDateTime() {
+      if (!this.appointment) return ''
+      return `${this.appointment.date} ${this.appointment.time}`
+    },
+    groupedNotes() {
+      const groups = {}
+      this.notes.forEach(n => {
+        const d = n.created_at.split('T')[0]
+        if (!groups[d]) groups[d] = []
+        groups[d].push(n)
+      })
+      return Object.keys(groups).sort((a,b) => new Date(b) - new Date(a)).map(date => ({ date, items: groups[date] }))
+    }
+  },
+  methods: {
+    formatDateTime(dt) {
+      return new Date(dt).toLocaleString('pt-BR')
+    },
+    handleFileChange(e) {
+      this.files = Array.from(e.target.files)
+    },
+    async fetchData() {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) {
+        this.$router.push('/login')
+        return
+      }
+      this.userId = user.id
+      const { data: appt } = await supabase
+        .from('appointments')
+        .select()
+        .eq('id', this.$route.params.id)
+        .single()
+      this.appointment = appt
+      const { data: notes } = await supabase
+        .from('appointment_notes')
+        .select()
+        .eq('appointment_id', this.$route.params.id)
+        .order('created_at', { ascending: false })
+      this.notes = notes || []
+    },
+    async saveNote() {
+      if (!this.note.trim() && !this.files.length) return
+      const attachmentUrls = []
+      for (const file of this.files) {
+        const ext = file.name.split('.').pop()
+        const fileName = `${this.$route.params.id}-${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`
+        const { error } = await supabase.storage.from('appointment-attachments').upload(fileName, file)
+        if (!error) {
+          const { data: { publicUrl } } = supabase.storage.from('appointment-attachments').getPublicUrl(fileName)
+          attachmentUrls.push(publicUrl)
+        }
+      }
+      const { data, error } = await supabase
+        .from('appointment_notes')
+        .insert({
+          appointment_id: this.$route.params.id,
+          user_id: this.userId,
+          note: this.note,
+          attachments: attachmentUrls
+        })
+        .select()
+        .single()
+      if (!error) {
+        this.notes.unshift(data)
+        this.note = ''
+        this.files = []
+      } else {
+        alert('Erro ao salvar atendimento: ' + error.message)
+      }
+    }
+  },
+  async mounted() {
+    await this.fetchData()
+  }
+}
+</script>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -205,7 +205,7 @@
           <p><strong>Duração:</strong> {{ selectedAppointment.duration }}</p>
           <p><strong>Descrição:</strong> {{ selectedAppointment.description }}</p>
         </div>
-        <div class="flex justify-end mt-4 space-x-2">
+        <div class="flex justify-center mt-4 space-x-2">
           <button @click="handleDeleteAppointment(selectedAppointment.id)" class="btn btn-danger">Excluir</button>
           <button @click="closeDetails" class="px-4 py-2 rounded border">Fechar</button>
         </div>

--- a/supabase/schemas/006_create_storage_policy.sql
+++ b/supabase/schemas/006_create_storage_policy.sql
@@ -8,5 +8,15 @@ FOR SELECT USING (
   bucket_id = 'profile-images'
 );
 
+CREATE POLICY "Anyone can upload appointment attachments" ON storage.objects
+FOR INSERT WITH CHECK (
+  bucket_id = 'appointment-attachments'
+);
+
+CREATE POLICY "Anyone can read appointment attachments" ON storage.objects
+FOR SELECT USING (
+  bucket_id = 'appointment-attachments'
+);
+
 -- Ensure RLS is enabled for storage.objects
 ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;

--- a/supabase/schemas/019_create_appointment_notes.sql
+++ b/supabase/schemas/019_create_appointment_notes.sql
@@ -1,0 +1,13 @@
+create table if not exists appointment_notes (
+  id uuid primary key default uuid_generate_v4(),
+  appointment_id uuid references appointments(id) on delete cascade,
+  user_id uuid references auth.users(id) on delete cascade,
+  note text,
+  attachments text[],
+  created_at timestamp with time zone default now()
+);
+
+alter table appointment_notes enable row level security;
+
+create policy "Users can manage own appointment notes" on appointment_notes
+  for all using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- merge main into work branch
- keep new Atendimento route and screen
- centralize buttons and reorder actions in appointment details modal
- allow starting an appointment via Atendimento page
- add Supabase policies and notes table

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e19f68388320b7d4937c4b66c63e