### PR TITLE
unify appointment details screen

### DIFF
--- a/src/components/AppointmentDetails.vue
+++ b/src/components/AppointmentDetails.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="relative">
+    <button
+      @click="$emit('close')"
+      class="absolute top-0 right-0 m-2 px-2 py-1 rounded border text-sm"
+    >
+      Fechar
+    </button>
+    <h3 class="text-lg font-semibold mb-4">Detalhes do Agendamento</h3>
+    <div v-if="appointment" class="space-y-1 border rounded-md p-4 bg-gray-50 text-gray-700">
+      <p><strong>Data:</strong> {{ appointment.date }}</p>
+      <p><strong>Hora:</strong> {{ appointment.time }}</p>
+      <p><strong>Cliente:</strong> {{ getClientName(appointment.client_id) }}</p>
+      <p><strong>Serviço:</strong> {{ getServiceName(appointment.service_id) }}</p>
+      <p><strong>Duração:</strong> {{ appointment.duration }}</p>
+      <p><strong>Descrição:</strong> {{ appointment.description }}</p>
+      <p v-if="appointment.room_id"><strong>Sala:</strong> {{ getRoomName(appointment.room_id) }}</p>
+      <p v-if="appointment.room_id && getRoomLink(appointment.room_id)">
+        <a :href="getRoomLink(appointment.room_id)" target="_blank" class="text-blue-600 underline">Acessar Google Meet</a>
+      </p>
+    </div>
+    <slot name="actions"></slot>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AppointmentDetails',
+  props: {
+    appointment: { type: Object, required: true },
+    getClientName: { type: Function, required: true },
+    getServiceName: { type: Function, required: true },
+    getRoomName: { type: Function, default: () => '' },
+    getRoomLink: { type: Function, default: () => '' }
+  }
+}
+</script>

--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -118,45 +118,34 @@
         </Modal>
 
         <Modal v-if="showDetailsModal" @close="closeDetails">
-          <div class="relative">
-            <button
-              @click="closeDetails"
-              class="absolute top-0 right-0 m-2 px-2 py-1 rounded border text-sm"
-            >
-              Fechar
-            </button>
-            <h3 class="text-lg font-semibold mb-4">Detalhes do Agendamento</h3>
-            <div v-if="selectedAppointment" class="space-y-1 border rounded-md p-4 bg-gray-50 text-gray-700">
-              <p><strong>Data:</strong> {{ selectedAppointment.date }}</p>
-              <p><strong>Hora:</strong> {{ selectedAppointment.time }}</p>
-              <p><strong>Cliente:</strong> {{ getClientName(selectedAppointment.client_id) }}</p>
-              <p><strong>Serviço:</strong> {{ getServiceName(selectedAppointment.service_id) }}</p>
-              <p><strong>Duração:</strong> {{ selectedAppointment.duration }}</p>
-              <p><strong>Descrição:</strong> {{ selectedAppointment.description }}</p>
-              <p v-if="selectedAppointment.room_id"><strong>Sala:</strong> {{ getRoomName(selectedAppointment.room_id) }}</p>
-              <p v-if="selectedAppointment.room_id && getRoomLink(selectedAppointment.room_id)">
-                <a :href="getRoomLink(selectedAppointment.room_id)" target="_blank" class="text-blue-600 underline">Acessar Google Meet</a>
-              </p>
-            </div>
-
-            <div class="mt-4">
-              <h4 class="font-medium mb-2">Ações de atendimento</h4>
-              <div class="flex flex-wrap justify-center gap-2">
-                <button @click="sendConfirmationWhatsApp" class="btn btn-success">Enviar confirmação</button>
-                <button @click="cancelAppointment" class="btn btn-warning">Desmarcou atendimento</button>
-                <button @click="markNoShow" class="btn btn-secondary">Faltou ao atendimento</button>
-                <button @click="startAppointment" class="btn btn-primary">Iniciar atendimento</button>
+          <AppointmentDetails
+            :appointment="selectedAppointment"
+            :getClientName="getClientName"
+            :getServiceName="getServiceName"
+            :getRoomName="getRoomName"
+            :getRoomLink="getRoomLink"
+            @close="closeDetails"
+          >
+            <template #actions>
+              <div class="mt-4">
+                <h4 class="font-medium mb-2">Ações de atendimento</h4>
+                <div class="flex flex-wrap justify-center gap-2">
+                  <button @click="sendConfirmationWhatsApp" class="btn btn-success">Enviar confirmação</button>
+                  <button @click="cancelAppointment" class="btn btn-warning">Desmarcou atendimento</button>
+                  <button @click="markNoShow" class="btn btn-secondary">Faltou ao atendimento</button>
+                  <button @click="startAppointment" class="btn btn-primary">Iniciar atendimento</button>
+                </div>
               </div>
-            </div>
 
-            <div class="mt-4">
-              <h4 class="font-medium mb-2">Ações de cadastro</h4>
-              <div class="flex flex-wrap justify-center gap-2">
-                <button @click="editFromDetails" class="btn">Editar</button>
-                <button @click="handleDeleteAppointment(selectedAppointment.id)" class="btn btn-danger">Excluir</button>
+              <div class="mt-4">
+                <h4 class="font-medium mb-2">Ações de cadastro</h4>
+                <div class="flex flex-wrap justify-center gap-2">
+                  <button @click="editFromDetails" class="btn">Editar</button>
+                  <button @click="handleDeleteAppointment(selectedAppointment.id)" class="btn btn-danger">Excluir</button>
+                </div>
               </div>
-            </div>
-          </div>
+            </template>
+          </AppointmentDetails>
         </Modal>
 
         <div class="mt-8" v-show="viewMode === 'list'">
@@ -241,13 +230,14 @@ import HeaderUser from '../components/HeaderUser.vue'
 import Modal from '../components/Modal.vue'
 import CalendarView from '../components/CalendarView.vue'
 import WeekView from '../components/WeekView.vue'
+import AppointmentDetails from '../components/AppointmentDetails.vue'
 import { supabase } from '../supabase'
 import { sendAppointmentEmail } from '../utils/email'
 import { digitsOnly } from '../utils/phone'
 
 export default {
   name: 'Agendamentos',
-  components: { Sidebar, HeaderUser, Modal, CalendarView, WeekView },
+  components: { Sidebar, HeaderUser, Modal, CalendarView, WeekView, AppointmentDetails },
   data() {
     return {
       userId: null,

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -196,19 +196,21 @@
       </Modal>
 
       <Modal v-if="showDetailsModal" @close="closeDetails">
-        <h3 class="text-lg font-semibold mb-4">Detalhes do Agendamento</h3>
-        <div v-if="selectedAppointment" class="space-y-1">
-          <p><strong>Data:</strong> {{ selectedAppointment.date }}</p>
-          <p><strong>Hora:</strong> {{ selectedAppointment.time }}</p>
-          <p><strong>Cliente:</strong> {{ getClientName(selectedAppointment.client_id) }}</p>
-          <p><strong>Serviço:</strong> {{ getServiceName(selectedAppointment.service_id) }}</p>
-          <p><strong>Duração:</strong> {{ selectedAppointment.duration }}</p>
-          <p><strong>Descrição:</strong> {{ selectedAppointment.description }}</p>
-        </div>
-        <div class="flex justify-center mt-4 space-x-2">
-          <button @click="handleDeleteAppointment(selectedAppointment.id)" class="btn btn-danger">Excluir</button>
-          <button @click="closeDetails" class="px-4 py-2 rounded border">Fechar</button>
-        </div>
+        <AppointmentDetails
+          :appointment="selectedAppointment"
+          :getClientName="getClientName"
+          :getServiceName="getServiceName"
+          :getRoomName="() => ''"
+          :getRoomLink="() => ''"
+          @close="closeDetails"
+        >
+          <template #actions>
+            <div class="flex justify-center mt-4 space-x-2">
+              <button @click="handleDeleteAppointment(selectedAppointment.id)" class="btn btn-danger">Excluir</button>
+              <button @click="closeDetails" class="px-4 py-2 rounded border">Fechar</button>
+            </div>
+          </template>
+        </AppointmentDetails>
       </Modal>
     </main>
   </div>
@@ -219,6 +221,7 @@ import Sidebar from '../components/Sidebar.vue'
 import HeaderUser from '../components/HeaderUser.vue'
 import Modal from '../components/Modal.vue'
 import WeekView from '../components/WeekView.vue'
+import AppointmentDetails from '../components/AppointmentDetails.vue'
 import { supabase } from '../supabase'
 import { Chart } from 'chart.js/auto'
 import { phoneMask } from '../utils/phone'
@@ -227,7 +230,7 @@ import { cpfMask, cepMask, isValidEmail } from '../utils/format'
 
 export default {
   name: 'Dashboard',
-  components: { Sidebar, HeaderUser, Modal, WeekView },
+  components: { Sidebar, HeaderUser, Modal, WeekView, AppointmentDetails },
   data() {
     return {
       userId: null,


### PR DESCRIPTION
## Summary
- add reusable `AppointmentDetails` component
- update "Agendamentos" and "Dashboard" views to use the new component

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e86cd51c83208210b554b0605b43