### PR TITLE
Fix double confirmation on cancel

### DIFF
--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -436,10 +436,8 @@ export default {
         }
       }
     },
-    async handleDeleteAppointment(id) {
-      const confirmed = confirm(
-        'Tem certeza que deseja excluir este agendamento?'
-      )
+    async handleDeleteAppointment(id, confirmMessage = 'Tem certeza que deseja excluir este agendamento?') {
+      const confirmed = confirm(confirmMessage)
       if (!confirmed) return
 
       const { error } = await supabase
@@ -502,9 +500,10 @@ export default {
     },
     async cancelAppointment() {
       if (!this.selectedAppointment) return
-      const confirmed = confirm('Tem certeza que deseja desmarcar este atendimento?')
-      if (!confirmed) return
-      await this.handleDeleteAppointment(this.selectedAppointment.id)
+      await this.handleDeleteAppointment(
+        this.selectedAppointment.id,
+        'Tem certeza que deseja desmarcar este atendimento?'
+      )
       this.closeDetails()
     },
     markNoShow() {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -471,10 +471,8 @@ export default {
         this.showDetailsModal = false
         this.selectedAppointment = null
       },
-      async handleDeleteAppointment(id) {
-        const confirmed = confirm(
-          'Tem certeza que deseja excluir este agendamento?'
-        )
+      async handleDeleteAppointment(id, confirmMessage = 'Tem certeza que deseja excluir este agendamento?') {
+        const confirmed = confirm(confirmMessage)
         if (!confirmed) return
 
         const { error } = await supabase
@@ -583,9 +581,10 @@ export default {
     },
     async cancelAppointment() {
       if (!this.selectedAppointment) return
-      const confirmed = confirm('Tem certeza que deseja desmarcar este atendimento?')
-      if (!confirmed) return
-      await this.handleDeleteAppointment(this.selectedAppointment.id)
+      await this.handleDeleteAppointment(
+        this.selectedAppointment.id,
+        'Tem certeza que deseja desmarcar este atendimento?'
+      )
       this.closeDetails()
     },
     markNoShow() {


### PR DESCRIPTION
## Summary
- ensure cancel appointment confirmation only shows once in dashboard
- ensure cancel appointment confirmation only shows once in schedules

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f3ec76e88320ba04ac55d917325b