### PR TITLE
Change menu label to Agendamentos

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -20,7 +20,7 @@
       <h2 class="text-2xl font-bold text-blue-600 mb-6">Agenda Zen</h2>
       <nav class="space-y-6 mt-8">
         <div class="space-y-2">
-          <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Atendimento</h3>
+          <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Agendamentos</h3>
           <router-link to="/dashboard" class="flex items-center text-gray-700 hover:text-blue-600">
             <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l9-9 9 9M4 10v10a1 1 0 001 1h3m10-11v10a1 1 0 01-1 1h-3m-6 0h6" />
@@ -34,7 +34,7 @@
               <line x1="8" y1="2" x2="8" y2="6" stroke-width="2"/>
               <line x1="3" y1="10" x2="21" y2="10" stroke-width="2"/>
             </svg>
-            <span>Atendimento</span>
+            <span>Agendamentos</span>
           </router-link>
         </div>
         <div class="space-y-2">


### PR DESCRIPTION
## Summary
- update sidebar menu label from Atendimento to **Agendamentos**

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856f4606a3483208dea66956645485e