### PR TITLE
Add Pix QR code generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "@supabase/supabase-js": "^2.49.8",
     "vue": "^3.0.0",
     "vue-router": "^4.5.1",
-    "chart.js": "^4.4.1"
+    "chart.js": "^4.4.1",
+    "qrcode": "^1.5.3"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.0.0",

--- a/src/utils/pix.js
+++ b/src/utils/pix.js
@@ -1,0 +1,43 @@
+export function formatPixField(id, value) {
+  const len = String(value.length).padStart(2, '0')
+  return `${id}${len}${value}`
+}
+
+export function crc16(str) {
+  let crc = 0xffff
+  for (let i = 0; i < str.length; i++) {
+    crc ^= str.charCodeAt(i) << 8
+    for (let j = 0; j < 8; j++) {
+      if (crc & 0x8000) {
+        crc = (crc << 1) ^ 0x1021
+      } else {
+        crc <<= 1
+      }
+      crc &= 0xffff
+    }
+  }
+  return crc.toString(16).toUpperCase().padStart(4, '0')
+}
+
+export function generatePixPayload({ key, name, city = 'SAO PAULO', amount, txid = 'AGENDAZEN' }) {
+  const merchantAccount =
+    formatPixField('00', 'BR.GOV.BCB.PIX') +
+    formatPixField('01', key)
+
+  const additionalData = formatPixField('05', txid)
+
+  const payloadWithoutCrc =
+    '000201' +
+    '26' + String(merchantAccount.length).padStart(2, '0') + merchantAccount +
+    '52040000' +
+    '5303986' +
+    (amount ? formatPixField('54', amount) : '') +
+    '5802BR' +
+    formatPixField('59', name) +
+    formatPixField('60', city) +
+    '62' + String(additionalData.length).padStart(2, '0') + additionalData +
+    '6304'
+
+  const crc = crc16(payloadWithoutCrc)
+  return payloadWithoutCrc + crc
+}

--- a/src/views/PagamentoPlus.vue
+++ b/src/views/PagamentoPlus.vue
@@ -99,11 +99,12 @@
         <div class="text-center space-y-4">
           <!-- Increase the Pix logo size by about 10% -->
           <img src="/logo_pix.png" alt="Logo Pix" class="mx-auto w-[17.6rem] h-auto" />
+          <img v-if="pixQrCode" :src="pixQrCode" alt="QR Code Pix" class="mx-auto w-40 h-auto" />
           <p class="font-semibold">Código de pagamento</p>
           <p>Copie e cole o código abaixo no app da sua instituição financeira para finalizar a compra.</p>
-          <p class="font-semibold">Valor do pagamento</p>
-          <p class="text-lg font-semibold">R$ 67,00</p>
           <input type="text" v-model="pixCode" readonly class="w-full px-4 py-2 border rounded-md text-center" />
+          <p class="font-semibold">Valor do pagamento</p>
+          <p class="text-lg font-semibold">R$ {{ pixAmount.replace('.', ',') }}</p>
         </div>
       </section>
     </main>
@@ -113,6 +114,8 @@
 <script>
 import Sidebar from '../components/Sidebar.vue'
 import HeaderUser from '../components/HeaderUser.vue'
+import QRCode from 'qrcode'
+import { generatePixPayload } from '../utils/pix.js'
 
 export default {
   name: 'PagamentoPlus',
@@ -120,7 +123,7 @@ export default {
   data() {
     return {
       sidebarOpen: window.innerWidth >= 768,
-      activeTab: 'cartao',
+      activeTab: 'pix',
       card: {
         name: '',
         number: '',
@@ -137,7 +140,25 @@ export default {
         city: '',
         state: ''
       },
-      pixCode: '000201010212...'
+      pixAmount: '67.00',
+      pixCode: '',
+      pixQrCode: ''
+    }
+  },
+  mounted() {
+    this.generatePix()
+  },
+  methods: {
+    generatePix() {
+      const payload = generatePixPayload({
+        key: '37775989840',
+        name: 'Jeferson Carlos A de Paula',
+        amount: this.pixAmount
+      })
+      this.pixCode = payload
+      QRCode.toDataURL(payload).then(url => {
+        this.pixQrCode = url
+      })
     }
   }
 }


### PR DESCRIPTION
## Summary
- default to Pix payment tab for Beta plan
- generate Pix copy/paste code and QR code image
- add utility for Pix payload generation
- include `qrcode` library

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b5ebe7948320a065e9520a2d6f7c