### PR TITLE
Fix plan-based QR code

### DIFF
--- a/src/views/MinhaAssinatura.vue
+++ b/src/views/MinhaAssinatura.vue
@@ -59,7 +59,11 @@ export default {
   },
   methods: {
     goBeta() {
-      this.$router.push('/assinatura-plus')
+      // Passa o valor do plano para a tela de pagamento
+      this.$router.push({
+        path: '/assinatura-plus',
+        query: { amount: '67.00' }
+      })
     },
     goBasico() {
       this.$router.push('/dashboard')

--- a/src/views/PagamentoPlus.vue
+++ b/src/views/PagamentoPlus.vue
@@ -140,12 +140,18 @@ export default {
         city: '',
         state: ''
       },
+      // Valor do pagamento será definido com base no plano selecionado
       pixAmount: '67.00',
       pixCode: '',
       pixQrCode: ''
     }
   },
   mounted() {
+    // Obtém o valor do plano via query string caso exista
+    const amount = this.$route.query.amount
+    if (amount) {
+      this.pixAmount = amount
+    }
     this.generatePix()
   },
   methods: {


### PR DESCRIPTION
## Summary
- route from plan selection to payment with chosen amount
- read the amount from query string on payment screen

## Testing
- `npx vite build` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6859b96418ac8320bc0fd4b4b21eedbf