### PR TITLE
Switch to 30-minute scheduling

### DIFF
--- a/src/components/WeekView.vue
+++ b/src/components/WeekView.vue
@@ -121,7 +121,7 @@ export default {
       const end = Math.min(23, parseInt(this.endTime.split(':')[0]) + 1)
       this.timeSlots = []
       for (let h = start; h <= end; h++) {
-        for (let m = 0; m < 60; m += 15) {
+        for (let m = 0; m < 60; m += 30) {
           this.timeSlots.push(
             `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
           )
@@ -156,7 +156,7 @@ export default {
       const nowMinutes = now.getHours() * 60 + now.getMinutes()
       const firstMinutes = firstH * 60 + firstM
       const diff = nowMinutes - firstMinutes
-      const pos = (diff / 15) * 16
+      const pos = (diff / 30) * 16
       this.currentLineTop = pos
     },
     prevWeek() {

--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -79,7 +79,7 @@
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-700">Hora</label>
-              <input type="time" v-model="form.time" class="w-full mt-1 px-4 py-2 border rounded-lg" />
+              <input type="time" step="1800" v-model="form.time" class="w-full mt-1 px-4 py-2 border rounded-lg" />
             </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">Cliente</label>

--- a/src/views/Configuracao.vue
+++ b/src/views/Configuracao.vue
@@ -122,9 +122,9 @@
             <div v-for="day in daysOfWeekOptions" :key="day.value" class="flex items-center space-x-2">
               <input type="checkbox" v-model="agenda.dailySchedule[day.value].enabled" />
               <span class="w-20">{{ day.label }}</span>
-              <input type="time" v-model="agenda.dailySchedule[day.value].start" class="border rounded-md px-2 py-1" />
+              <input type="time" step="1800" v-model="agenda.dailySchedule[day.value].start" class="border rounded-md px-2 py-1" />
               <span>-</span>
-              <input type="time" v-model="agenda.dailySchedule[day.value].end" class="border rounded-md px-2 py-1" />
+              <input type="time" step="1800" v-model="agenda.dailySchedule[day.value].end" class="border rounded-md px-2 py-1" />
             </div>
           </div>
         </div>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -166,7 +166,7 @@
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">Hora</label>
-            <input type="time" v-model="appointmentForm.time" class="w-full mt-1 px-4 py-2 border rounded-md" />
+            <input type="time" step="1800" v-model="appointmentForm.time" class="w-full mt-1 px-4 py-2 border rounded-md" />
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">Cliente</label>

--- a/src/views/Onboarding.vue
+++ b/src/views/Onboarding.vue
@@ -26,11 +26,11 @@
         <h2 class="text-xl font-semibold mb-4">Horários de atendimento</h2>
         <div>
           <label class="block text-sm font-medium text-gray-700">Início</label>
-          <input type="time" v-model="agenda.startTime" class="w-full mt-1 px-4 py-2 border rounded-md" />
+          <input type="time" step="1800" v-model="agenda.startTime" class="w-full mt-1 px-4 py-2 border rounded-md" />
         </div>
         <div>
           <label class="block text-sm font-medium text-gray-700">Fim</label>
-          <input type="time" v-model="agenda.endTime" class="w-full mt-1 px-4 py-2 border rounded-md" />
+          <input type="time" step="1800" v-model="agenda.endTime" class="w-full mt-1 px-4 py-2 border rounded-md" />
         </div>
         <div>
           <label class="block text-sm font-medium text-gray-700">Dias da semana</label>


### PR DESCRIPTION
## Summary
- update `WeekView` to build slots every 30 minutes
- use a 30‑minute step on time inputs across the app

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859bf55435883209518794ca35e7886