### PR TITLE
Remove countdown from hero banner

### DIFF
--- a/src/components/HeroBanner.vue
+++ b/src/components/HeroBanner.vue
@@ -9,9 +9,6 @@
                 <router-link to="/login" class="bg-white border border-blue-600 text-blue-600 px-6 py-2 rounded hover:bg-blue-100">Entrar</router-link>
                 <router-link to="/cadastro" class="btn">Criar conta</router-link>
             </div>
-            <div class="mt-6 text-2xl text-blue-600 font-semibold">
-              Tempo restante: {{ formattedTime }}
-            </div>
           </div>
           <div>
             <img src="/hero-illustration.png" alt="Ilustração profissional usando a plataforma" class="w-full h-auto mx-auto">
@@ -23,31 +20,6 @@
   
   <script>
   export default {
-    name: 'HeroBanner',
-    data() {
-      return {
-        timeLeft: 300,
-        intervalId: null
-      }
-    },
-    computed: {
-      formattedTime() {
-        const minutes = Math.floor(this.timeLeft / 60).toString().padStart(2, '0')
-        const seconds = (this.timeLeft % 60).toString().padStart(2, '0')
-        return `${minutes}:${seconds}`
-      }
-    },
-    mounted() {
-      this.intervalId = setInterval(() => {
-        if (this.timeLeft > 0) {
-          this.timeLeft--
-        } else {
-          clearInterval(this.intervalId)
-        }
-      }, 1000)
-    },
-    beforeUnmount() {
-      clearInterval(this.intervalId)
-    }
+    name: 'HeroBanner'
   }
   </script>


### PR DESCRIPTION
## Summary
- remove countdown from hero banner on home

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c9fc57c0832090d0a52c7a63eea4