### PR TITLE
Implement client tabs with scheduling and history

### DIFF
--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -661,6 +661,12 @@ export default {
     if (appointmentData) {
       this.appointments = appointmentData
     }
+
+    const editId = this.$route.query.edit
+    if (editId) {
+      const appt = this.appointments.find(a => a.id === editId)
+      if (appt) this.openModal(appt)
+    }
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- add tab navigation to client modal
- list appointments in Agendamentos tab with edit buttons
- show client attendance history with edit links
- support opening appointment edit via query parameter

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d275cb048320a5b73930a7c6a118