### PR TITLE
Fix history refresh after editing note

### DIFF
--- a/src/views/Atendimento.vue
+++ b/src/views/Atendimento.vue
@@ -231,6 +231,21 @@ export default {
       }
     }
   },
+  watch: {
+    '$route.params.id'() {
+      this.fetchData()
+    },
+    '$route.query.note'(val) {
+      if (!val) {
+        if (this.isEditing) this.cancelEdit()
+        return
+      }
+      const note = this.notes.find(n => n.id === Number(val) || n.id === val)
+      if (note) {
+        this.editExistingNote(note)
+      }
+    }
+  },
   async mounted() {
     await this.fetchData()
   }


### PR DESCRIPTION
## Summary
- refresh appointment history when the route changes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d907b4c483208defa0f1baac8051