### PR TITLE
fix cors headers in email function

### DIFF
--- a/supabase/functions/send-appointment-email/index.ts
+++ b/supabase/functions/send-appointment-email/index.ts
@@ -2,8 +2,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers':
-    'authorization, x-client-info, apikey, content-type',
+  // Allow any headers in CORS preflight to avoid 403 responses
+  'Access-Control-Allow-Headers': '*',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Max-Age': '86400'
 }


### PR DESCRIPTION
## Summary
- allow any headers in Edge Function CORS settings

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e1fd57708320b4c78c12b6a0569f