### PR TITLE
Fix CORS handling for email function

### DIFF
--- a/supabase/functions/send-appointment-email/index.ts
+++ b/supabase/functions/send-appointment-email/index.ts
@@ -1,14 +1,16 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 
-const corsHeaders = {
+const baseHeaders = {
   'Access-Control-Allow-Origin': '*',
-  // Allow any headers in CORS preflight to avoid 403 responses
-  'Access-Control-Allow-Headers': '*',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Max-Age': '86400'
 }
 
 serve(async req => {
+  const allowHeaders =
+    req.headers.get('access-control-request-headers') || '*'
+  const corsHeaders = { ...baseHeaders, 'Access-Control-Allow-Headers': allowHeaders }
+
   if (req.method === 'OPTIONS') {
     // Return a 200 response for CORS preflight requests
     return new Response('ok', { status: 200, headers: corsHeaders })


### PR DESCRIPTION
## Summary
- fix CORS preflight handling on `send-appointment-email` edge function

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e55d8b448320b3a009378466b11b