### PR TITLE
Update CORS headers for email function

### DIFF
--- a/supabase/functions/send-appointment-email/index.ts
+++ b/supabase/functions/send-appointment-email/index.ts
@@ -1,15 +1,14 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 
-const baseHeaders = {
+const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers':
+    'authorization, x-client-info, apikey, content-type',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Max-Age': '86400'
 }
 
 serve(async req => {
-  const allowHeaders =
-    req.headers.get('access-control-request-headers') || '*'
-  const corsHeaders = { ...baseHeaders, 'Access-Control-Allow-Headers': allowHeaders }
 
   if (req.method === 'OPTIONS') {
     // Return a 200 response for CORS preflight requests


### PR DESCRIPTION
## Summary
- update `send-appointment-email` edge function to return explicit header list for CORS

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e6c093e08320888a662a265ca091