### PR TITLE
Add edge function deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ O diretório `supabase/schemas` reúne os scripts SQL para criação das tabelas
 - `npm run preview` – serve localmente os arquivos de produção
 - `npm run deploy` – publica a pasta `dist` no GitHub Pages
 
+### Deploy de funções Edge
+
+Se criar ou modificar um arquivo em `supabase/functions`, execute o deploy para
+que o endpoint seja disponibilizado:
+
+```bash
+supabase functions deploy send-appointment-email
+```
+
+No painel do Supabase você consegue acompanhar os logs e confirmar se as
+requisições estão chegando normalmente.
+
 ## Estrutura do projeto
 
 - `src/` – código-fonte em Vue (componentes, views e roteamento)

--- a/supabase/functions/send-appointment-email/index.ts
+++ b/supabase/functions/send-appointment-email/index.ts
@@ -9,6 +9,7 @@ const corsHeaders = {
 }
 
 serve(async req => {
+  console.log('Edge Function request:', req.method)
 
   if (req.method === 'OPTIONS') {
     // Return a 200 response for CORS preflight requests


### PR DESCRIPTION
## Summary
- document how to deploy Supabase edge functions
- log incoming requests in the send-appointment-email function

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859ee1d6a9083209ecba505a43bc8d5