### PR TITLE
Adjust email confirmation alerts

### DIFF
--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -1,12 +1,12 @@
 import { supabase } from '../supabase'
 
-export async function sendAppointmentEmail(details) {
+export async function sendAppointmentEmail(details, notify = true) {
   const { error } = await supabase.functions.invoke('send-appointment-email', {
     body: details
   })
   if (error) {
     console.error('Erro ao enviar email de agendamento:', error.message)
-  } else {
+  } else if (notify) {
     alert('E-mail enviado com sucesso!')
   }
 }

--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -445,7 +445,7 @@ export default {
               `${room?.google_meet_link ? `Link: ${room.google_meet_link}\n` : ''}` +
               `${this.form.description ? `Observações: ${this.form.description}\n` : ''}` +
               `\nE-mail enviado automaticamente.`
-          })
+          }, false)
           this.closeModal()
         }
       }


### PR DESCRIPTION
## Summary
- make appointment email alert optional
- suppress alert after saving appointments

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0f24f22c8320b68afc74e6a27f35