### PR TITLE
Add minutes text after service durations

### DIFF
--- a/src/components/AppointmentDetails.vue
+++ b/src/components/AppointmentDetails.vue
@@ -12,7 +12,7 @@
       <p><strong>Hora:</strong> {{ appointment.time }}</p>
       <p><strong>Cliente:</strong> {{ getClientName(appointment.client_id) }}</p>
       <p><strong>Serviço:</strong> {{ getServiceName(appointment.service_id) }}</p>
-      <p><strong>Duração:</strong> {{ appointment.duration }}</p>
+      <p><strong>Duração:</strong> {{ appointment.duration }} minutos</p>
       <p><strong>Descrição:</strong> {{ appointment.description }}</p>
       <p v-if="appointment.room_id"><strong>Sala:</strong> {{ getRoomName(appointment.room_id) }}</p>
       <p v-if="appointment.room_id && getRoomLink(appointment.room_id)">

--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -185,7 +185,7 @@
                   <td class="px-4 py-2">{{ getClientName(appointment.client_id) }}</td>
                   <td class="px-4 py-2">{{ getServiceName(appointment.service_id) }}</td>
                   <td class="px-4 py-2">{{ getRoomName(appointment.room_id) }}</td>
-                  <td class="px-4 py-2">{{ appointment.duration }}</td>
+                  <td class="px-4 py-2">{{ appointment.duration }} minutos</td>
                   <td class="px-4 py-2">{{ appointment.description }}</td>
                   <td class="px-4 py-2 text-right space-x-2">
                     <button @click="openModal(appointment)" class="btn btn-sm">Editar</button>

--- a/src/views/Onboarding.vue
+++ b/src/views/Onboarding.vue
@@ -57,7 +57,7 @@
         </div>
         <ul class="mt-4 space-y-1">
           <li v-for="(s, index) in services" :key="index" class="flex justify-between">
-            <span>{{ s.name }} - {{ s.duration }}min - {{ formatPrice(s.price) }}</span>
+            <span>{{ s.name }} - {{ s.duration }} minutos - {{ formatPrice(s.price) }}</span>
             <button @click="removeService(index)" class="text-red-600 hover:underline">Remover</button>
           </li>
         </ul>

--- a/src/views/PublicPage.vue
+++ b/src/views/PublicPage.vue
@@ -17,7 +17,7 @@
             <li v-for="service in services" :key="service.id" class="p-4 bg-gray-50 border rounded-lg shadow">
               <h3 class="text-lg font-medium text-blue-700">{{ service.name }}</h3>
               <p class="text-sm text-gray-600">{{ service.description }}</p>
-              <p class="text-sm text-gray-500 mt-1">Duração: {{ service.duration }}</p>
+              <p class="text-sm text-gray-500 mt-1">Duração: {{ service.duration }} minutos</p>
               <p class="text-sm text-gray-500">Valor: {{ formatPrice(service.price) }}</p>
             </li>
           </ul>

--- a/src/views/Servicos.vue
+++ b/src/views/Servicos.vue
@@ -49,7 +49,7 @@
               >
                 <td class="px-4 py-2">{{ service.name }}</td>
                 <td class="px-4 py-2">{{ service.description }}</td>
-                <td class="px-4 py-2">{{ service.duration }}</td>
+                <td class="px-4 py-2">{{ service.duration }} minutos</td>
                 <td class="px-4 py-2">{{ formatPrice(service.price) }}</td>
                 <td class="px-4 py-2 text-right space-x-2">
                   <button


### PR DESCRIPTION
## Summary
- show duration units on services list
- show duration units on public page
- show duration units in appointment details and table
- show duration units in onboarding service list

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0fe18c0883208b60c442fb5edaaf