### PR TITLE
Fix closing tag in WeekView.vue

### DIFF
--- a/src/components/WeekView.vue
+++ b/src/components/WeekView.vue
@@ -60,7 +60,6 @@
         </div>
       </div>
     </div>
-  </div>
 </template>
 
 <script>


### PR DESCRIPTION
## Summary
- remove stray closing div tag from WeekView template

## Testing
- `npm run build` *(fails: vite not found because dependencies aren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a11802bf083208fbaedbbb03328e0