### PR TITLE
Fix week view alignment

### DIFF
--- a/src/components/WeekView.vue
+++ b/src/components/WeekView.vue
@@ -93,7 +93,7 @@ export default {
       startTime: '00:00',
       endTime: '23:00',
       dailySchedule: null,
-      slotInterval: 60,
+      slotInterval: 30,
       timeSlots: [],
       currentLineTop: 0,
       lineInterval: null


### PR DESCRIPTION
## Summary
- fix time slot alignment so that appointments start in the correct cell

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a16aa07b48320a9d2c241fa38990e