### PR TITLE
Adjust appointment list actions and week view display

### DIFF
--- a/src/components/WeekView.vue
+++ b/src/components/WeekView.vue
@@ -44,7 +44,7 @@
           :style="getEventStyle(event)"
           @click="$emit('select', event.appointment)"
         >
-          {{ event.title }}
+          {{ event.title }} - {{ event.startTime }}
         </div>
       </div>
     </div>

--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -188,8 +188,7 @@
                   <td class="px-4 py-2">{{ appointment.duration }} minutos</td>
                   <td class="px-4 py-2">{{ appointment.description }}</td>
                   <td class="px-4 py-2 text-right space-x-2">
-                    <button @click="openModal(appointment)" class="btn btn-sm">Editar</button>
-                    <button @click="handleDeleteAppointment(appointment.id)" class="btn btn-sm btn-danger">Excluir</button>
+                    <button @click="openDetails(appointment)" class="btn btn-sm">Visualizar</button>
                   </td>
                 </tr>
                 <tr v-if="processedAppointments.length === 0">


### PR DESCRIPTION
## Summary
- remove edit/delete actions from appointments list
- add `Visualizar` button to open appointment details
- show start time in weekly agenda events

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab1b71d808320bbf7085eaf2e1c34