### PR TITLE
Fix timezone handling for appointment display

### DIFF
--- a/src/components/WeekView.vue
+++ b/src/components/WeekView.vue
@@ -53,6 +53,7 @@
 
 <script>
 import { formatDateBR } from '../utils/format'
+import { getBrazilNow, parseBrazilDateTime } from '../utils/datetime'
 
 export default {
   name: 'WeekView',
@@ -75,7 +76,7 @@ export default {
     }
   },
   data() {
-    const today = new Date()
+    const today = getBrazilNow()
     // calculate monday as start of week (1) with sunday as 7
     const dayOfWeek = today.getDay() === 0 ? 7 : today.getDay()
     const start = new Date(today)
@@ -98,7 +99,7 @@ export default {
     },
     computedEndHour() {
       const hours = this.appointments.map(a => {
-        const startDate = new Date(`${a.date}T${a.time}`)
+        const startDate = parseBrazilDateTime(a.date, a.time)
         const endDate = new Date(startDate.getTime() + Number(a.duration || 0) * 60000)
         return endDate.getMinutes() > 0 ? endDate.getHours() + 1 : endDate.getHours()
       })
@@ -119,7 +120,7 @@ export default {
         .filter(a => a.date >= startStr && a.date <= endStr)
         .map(a => {
           const [hour, minute] = a.time.split(':')
-          const startDate = new Date(`${a.date}T${a.time}`)
+          const startDate = parseBrazilDateTime(a.date, a.time)
           const endDate = new Date(startDate.getTime() + Number(a.duration || 0) * 60000)
           const day = startDate.getDay() === 0 ? 7 : startDate.getDay()
           return {

--- a/src/utils/datetime.js
+++ b/src/utils/datetime.js
@@ -1,0 +1,15 @@
+export function getBrazilNow() {
+  return new Date(
+    new Date().toLocaleString('en-US', { timeZone: 'America/Sao_Paulo' })
+  )
+}
+
+export function parseBrazilDateTime(dateStr, timeStr) {
+  if (!dateStr || !timeStr) return new Date(
+    new Date().toLocaleString('en-US', { timeZone: 'America/Sao_Paulo' })
+  )
+  const iso = `${dateStr}T${timeStr}`
+  return new Date(
+    new Date(iso).toLocaleString('en-US', { timeZone: 'America/Sao_Paulo' })
+  )
+}

--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -236,6 +236,7 @@ import { supabase } from '../supabase'
 import { sendAppointmentEmail } from '../utils/email'
 import { digitsOnly } from '../utils/phone'
 import { formatDateBR } from '../utils/format'
+import { getBrazilNow, parseBrazilDateTime } from '../utils/datetime'
 
 export default {
   name: 'Agendamentos',
@@ -389,8 +390,8 @@ export default {
     canCancelAppointment(appt) {
       const limit = this.schedule.cancelLimitHours || 0
       if (limit === 0) return true
-      const apptTime = new Date(`${appt.date}T${appt.time}`)
-      const diffHours = (apptTime - new Date()) / 36e5
+      const apptTime = parseBrazilDateTime(appt.date, appt.time)
+      const diffHours = (apptTime - getBrazilNow()) / 36e5
       return diffHours >= limit
     },
     async handleSaveAppointment() {


### PR DESCRIPTION
## Summary
- add helper to handle Brazil timezone conversion
- use new helper in WeekView
- update appointment cancel policy to consider Brazil timezone

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b5761f484832096bf05a3ea78a9a9