### PR TITLE
Fix agenda range around working hours

### DIFF
--- a/src/components/WeekView.vue
+++ b/src/components/WeekView.vue
@@ -92,22 +92,10 @@ export default {
   },
   computed: {
     computedStartHour() {
-      const hours = this.appointments.map(a => parseInt(a.time.split(':')[0]))
-      const minAppt = hours.length ? Math.min(...hours) : this.startHour
-      const start = Math.min(this.startHour, minAppt)
-      return isNaN(start) ? this.startHour : start
+      return this.startHour
     },
     computedEndHour() {
-      const hours = this.appointments.map(a => {
-        const startDate = parseBrazilDateTime(a.date, a.time)
-        const endDate = new Date(startDate.getTime() + Number(a.duration || 0) * 60000)
-        return endDate.getMinutes() > 0 ? endDate.getHours() + 1 : endDate.getHours()
-      })
-      const maxAppt = hours.length ? Math.max(...hours) : this.endHour
-      let end = Math.max(this.endHour, maxAppt)
-      if (isNaN(end)) end = this.startHour
-      if (end < this.startHour) end = this.startHour
-      return end
+      return this.endHour
     },
     totalHours() {
       return Math.max(0, this.computedEndHour - this.computedStartHour + 1)

--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -329,11 +329,13 @@ export default {
     },
     scheduleStartHour() {
       const t = this.schedule.startTime
-      return t ? parseInt(t.split(':')[0]) : 6
+      const hour = t ? parseInt(t.split(':')[0]) : 6
+      return Math.max(0, hour - 1)
     },
     scheduleEndHour() {
       const t = this.schedule.endTime
-      return t ? parseInt(t.split(':')[0]) : 23
+      const hour = t ? parseInt(t.split(':')[0]) : 23
+      return Math.min(23, hour + 1)
     }
   },
   methods: {


### PR DESCRIPTION
## Summary
- keep weekly agenda fixed by using given start/end hours
- always show one hour before/after working hours on Agendamentos page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b5a6a0aa88320b328069961a6190e