### PR TITLE
Shift agenda display by +1h

### DIFF
--- a/src/components/AppointmentDetails.vue
+++ b/src/components/AppointmentDetails.vue
@@ -9,7 +9,7 @@
     <h3 class="text-lg font-semibold mb-4">Detalhes do Agendamento</h3>
     <div v-if="appointment" class="space-y-1 border rounded-md p-4 bg-gray-50 text-gray-700">
       <p><strong>Data:</strong> {{ appointment.date }}</p>
-      <p><strong>Hora:</strong> {{ appointment.time }}</p>
+      <p><strong>Hora:</strong> {{ addHoursToTime(appointment.time) }}</p>
       <p><strong>Cliente:</strong> {{ getClientName(appointment.client_id) }}</p>
       <p><strong>Serviço:</strong> {{ getServiceName(appointment.service_id) }}</p>
       <p><strong>Duração:</strong> {{ appointment.duration }} minutos</p>
@@ -24,6 +24,7 @@
 </template>
 
 <script>
+import { addHoursToTime } from '../utils/datetime'
 export default {
   name: 'AppointmentDetails',
   props: {

--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -36,7 +36,7 @@
             class="text-xs truncate cursor-pointer"
             @click="$emit('select', appt)"
           >
-            {{ appt.time }} - {{ getClientName(appt.client_id) }}
+            {{ addHoursToTime(appt.time) }} - {{ getClientName(appt.client_id) }}
           </li>
         </ul>
       </div>
@@ -45,6 +45,7 @@
 </template>
 
 <script>
+import { addHoursToTime } from '../utils/datetime'
 export default {
   name: 'CalendarView',
   props: {

--- a/src/components/WeekView.vue
+++ b/src/components/WeekView.vue
@@ -53,7 +53,7 @@
 
 <script>
 import { formatDateBR } from '../utils/format'
-import { getBrazilNow, parseBrazilDateTime } from '../utils/datetime'
+import { getBrazilNow, parseBrazilDateTime, addHoursToTime } from '../utils/datetime'
 
 export default {
   name: 'WeekView',
@@ -107,8 +107,9 @@ export default {
       const events = this.appointments
         .filter(a => a.date >= startStr && a.date <= endStr)
         .map(a => {
-          const [hour, minute] = a.time.split(':')
-          const startDate = parseBrazilDateTime(a.date, a.time)
+          const adjTime = addHoursToTime(a.time)
+          const [hour, minute] = adjTime.split(':')
+          const startDate = parseBrazilDateTime(a.date, adjTime)
           const endDate = new Date(startDate.getTime() + Number(a.duration || 0) * 60000)
           const day = startDate.getDay() === 0 ? 7 : startDate.getDay()
           return {

--- a/src/utils/datetime.js
+++ b/src/utils/datetime.js
@@ -13,3 +13,16 @@ export function parseBrazilDateTime(dateStr, timeStr) {
     new Date(iso).toLocaleString('en-US', { timeZone: 'America/Sao_Paulo' })
   )
 }
+
+export function addHoursToTime(timeStr, hours = 1) {
+  if (!timeStr) return ''
+  const [h, m] = timeStr.split(':').map(Number)
+  const date = new Date()
+  date.setHours(h)
+  date.setMinutes(m)
+  date.setSeconds(0)
+  date.setMinutes(date.getMinutes() + hours * 60)
+  const newH = String(date.getHours()).padStart(2, '0')
+  const newM = String(date.getMinutes()).padStart(2, '0')
+  return `${newH}:${newM}`
+}

--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -181,7 +181,7 @@
               </thead>
               <tbody>
                 <tr v-for="appointment in processedAppointments" :key="appointment.id" class="border-b last:border-b-0">
-                  <td class="px-4 py-2">{{ formatDateBR(appointment.date) }} {{ appointment.time }}</td>
+                  <td class="px-4 py-2">{{ formatDateBR(appointment.date) }} {{ addHoursToTime(appointment.time) }}</td>
                   <td class="px-4 py-2">{{ getClientName(appointment.client_id) }}</td>
                   <td class="px-4 py-2">{{ getServiceName(appointment.service_id) }}</td>
                   <td class="px-4 py-2">{{ getRoomName(appointment.room_id) }}</td>
@@ -236,7 +236,7 @@ import { supabase } from '../supabase'
 import { sendAppointmentEmail } from '../utils/email'
 import { digitsOnly } from '../utils/phone'
 import { formatDateBR } from '../utils/format'
-import { getBrazilNow, parseBrazilDateTime } from '../utils/datetime'
+import { getBrazilNow, parseBrazilDateTime, addHoursToTime } from '../utils/datetime'
 
 export default {
   name: 'Agendamentos',
@@ -555,7 +555,7 @@ export default {
         subject: 'Agendamento de Consulta realizado',
         text:
           `Olá ${client?.name},\n\n` +
-          `Seu agendamento para ${service?.name} foi confirmado para ${formatDateBR(appt.date)} às ${appt.time}.\n` +
+          `Seu agendamento para ${service?.name} foi confirmado para ${formatDateBR(appt.date)} às ${addHoursToTime(appt.time)}.\n` +
           `${room ? `Sala: ${room.name}\n` : ''}` +
           `${room?.google_meet_link ? `Link: ${room.google_meet_link}\n` : ''}` +
           `${appt.description ? `Observações: ${appt.description}\n` : ''}` +
@@ -576,7 +576,7 @@ export default {
         `Passando para informar que seu agendamento está confirmado!\n\n` +
         `Segue os dados para consulta:\n` +
         `Cliente: ${client.name}\n` +
-        `Data: ${formatDateBR(appt.date)} - Hora: ${appt.time}\n` +
+        `Data: ${formatDateBR(appt.date)} - Hora: ${addHoursToTime(appt.time)}\n` +
         `Sala: ${room?.google_meet_link || ''}\n\n` +
         `Obrigado.\n\n` +
         `Está mensagem é uma mensagem automática.`
@@ -588,7 +588,7 @@ export default {
       const headers = ['Data', 'Hora', 'Cliente', 'Serviço', 'Duração', 'Descrição']
       const rows = this.appointments.map(a => [
         formatDateBR(a.date),
-        a.time,
+        addHoursToTime(a.time),
         this.getClientName(a.client_id),
         this.getServiceName(a.service_id),
         a.duration,

--- a/src/views/Atendimento.vue
+++ b/src/views/Atendimento.vue
@@ -57,6 +57,7 @@ import Sidebar from '../components/Sidebar.vue'
 import HeaderUser from '../components/HeaderUser.vue'
 import { supabase } from '../supabase'
 import { formatDateBR } from '../utils/format'
+import { addHoursToTime } from '../utils/datetime'
 
 export default {
   name: 'Atendimento',
@@ -78,7 +79,7 @@ export default {
   computed: {
     appointmentDateTime() {
       if (!this.appointment) return ''
-      return `${formatDateBR(this.appointment.date)} ${this.appointment.time}`
+      return `${formatDateBR(this.appointment.date)} ${addHoursToTime(this.appointment.time)}`
     },
     groupedNotes() {
       const groups = {}

--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -207,7 +207,7 @@
             </thead>
             <tbody>
               <tr v-for="a in clientAppointments" :key="a.id" class="border-b last:border-b-0">
-                <td class="px-4 py-2">{{ formatDateBR(a.date) }} {{ a.time }}</td>
+                <td class="px-4 py-2">{{ formatDateBR(a.date) }} {{ addHoursToTime(a.time) }}</td>
                 <td class="px-4 py-2">{{ getServiceName(a.service_id) }}</td>
                 <td class="px-4 py-2 text-right space-x-2">
                   <router-link :to="{ path: '/agendamentos', query: { edit: a.id } }" class="btn btn-sm">Editar</router-link>
@@ -223,7 +223,7 @@
 
         <div v-show="activeTab === 'historico'" class="space-y-4">
           <div v-for="h in history" :key="h.id" class="border p-2 rounded">
-            <p class="text-sm text-gray-600 mb-1">{{ formatDateBR(h.appointment.date) }} {{ h.appointment.time }}</p>
+            <p class="text-sm text-gray-600 mb-1">{{ formatDateBR(h.appointment.date) }} {{ addHoursToTime(h.appointment.time) }}</p>
             <p class="mb-2 whitespace-pre-line">{{ h.note }}</p>
             <div v-if="h.attachments && h.attachments.length" class="space-x-2 mb-2">
               <a v-for="(url, idx) in h.attachments" :key="idx" :href="url" target="_blank" download class="text-blue-600 underline">Anexo {{ idx + 1 }}</a>
@@ -248,6 +248,7 @@ import { supabase } from '../supabase'
 import { phoneMask, digitsOnly } from '../utils/phone'
 import { fetchStates, fetchCities } from '../utils/locations'
 import { cpfMask, cepMask, isValidEmail, formatDateBR } from '../utils/format'
+import { addHoursToTime } from '../utils/datetime'
 import { sendAppointmentEmail } from '../utils/email'
 
 export default {
@@ -501,7 +502,7 @@ export default {
         subject: 'Agendamento de Consulta realizado',
         text:
           `Olá ${client?.name},\n\n` +
-          `Seu agendamento para ${service?.name} foi confirmado para ${formatDateBR(appt.date)} às ${appt.time}.\n` +
+          `Seu agendamento para ${service?.name} foi confirmado para ${formatDateBR(appt.date)} às ${addHoursToTime(appt.time)}.\n` +
           `${room ? `Sala: ${room.name}\n` : ''}` +
           `${room?.google_meet_link ? `Link: ${room.google_meet_link}\n` : ''}` +
           `${appt.description ? `Observações: ${appt.description}\n` : ''}` +

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -243,6 +243,7 @@ import { Chart } from 'chart.js/auto'
 import { phoneMask, digitsOnly } from '../utils/phone'
 import { fetchStates, fetchCities } from '../utils/locations'
 import { cpfMask, cepMask, isValidEmail, formatDateBR } from '../utils/format'
+import { addHoursToTime } from '../utils/datetime'
 
 export default {
   name: 'Dashboard',
@@ -604,7 +605,7 @@ export default {
         `Passando para informar que seu agendamento está confirmado!\n\n` +
         `Segue os dados para consulta:\n` +
         `Cliente: ${client.name}\n` +
-        `Data: ${formatDateBR(appt.date)} - Hora: ${appt.time}\n` +
+        `Data: ${formatDateBR(appt.date)} - Hora: ${addHoursToTime(appt.time)}\n` +
         `Sala: ${room?.google_meet_link || ''}\n\n` +
         `Obrigado.\n\n` +
         `Está mensagem é uma mensagem automática.`


### PR DESCRIPTION
## Summary
- introduce `addHoursToTime` helper to shift a time string
- show appointments with one hour added in list, calendar and week views
- adjust confirmation messages and client history to use the new time

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b5d0a75008320b8f09c72705f8f8c