### PR TITLE
Fix addHoursToTime runtime error

### DIFF
--- a/src/components/AppointmentDetails.vue
+++ b/src/components/AppointmentDetails.vue
@@ -33,6 +33,9 @@ export default {
     getServiceName: { type: Function, required: true },
     getRoomName: { type: Function, default: () => '' },
     getRoomLink: { type: Function, default: () => '' }
+  },
+  methods: {
+    addHoursToTime
   }
 }
 </script>

--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -76,6 +76,7 @@ export default {
     }
   },
   methods: {
+    addHoursToTime,
     prevMonth() {
       if (this.currentMonth === 0) {
         this.currentMonth = 11

--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -340,6 +340,7 @@ export default {
   },
   methods: {
     formatDateBR,
+    addHoursToTime,
     openModal(appointment) {
       if (appointment) {
         this.editingId = appointment.id

--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -295,6 +295,7 @@ export default {
     cpfMask,
     cepMask,
     formatDateBR,
+    addHoursToTime,
     async fetchServicesList() {
       const { data } = await supabase
         .from('services')


### PR DESCRIPTION
## Summary
- expose `addHoursToTime` helper in components and views that use it in templates

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b5f02c9b48320b178725e535b0782