### PR TITLE
Implement scheduling via public page

### DIFF
--- a/src/components/WeekView.vue
+++ b/src/components/WeekView.vue
@@ -40,8 +40,10 @@
         <div
           v-for="event in events"
           :key="event.id"
-          class="absolute bg-blue-500 text-white rounded px-2 py-1 event cursor-pointer"
+          class="absolute text-white rounded px-2 py-1 event cursor-pointer"
+          :class="event.appointment.confirmed ? 'bg-blue-500' : 'bg-red-500'"
           :style="getEventStyle(event)"
+          :title="event.appointment.confirmed ? '' : 'pendente confirmação de pagamento'"
           @click="$emit('select', event.appointment)"
         >
           {{ event.title }} - {{ event.startTime }}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -23,6 +23,7 @@ import Faq from '../views/Faq.vue'
 import PoliticaPrivacidade from '../views/PoliticaPrivacidade.vue'
 import TermosDeUso from '../views/TermosDeUso.vue'
 import PagamentoPlus from '../views/PagamentoPlus.vue'
+import PagamentoAgendamento from '../views/PagamentoAgendamento.vue'
 import Confirmacao from '../views/Confirmacao.vue'
 import LinkExpirado from '../views/LinkExpirado.vue'
 import { supabase } from '../supabase'
@@ -54,6 +55,7 @@ const routes = [
   { path: '/politica-de-privacidade', name: 'PoliticaDePrivacidade', component: PoliticaPrivacidade },
   { path: '/termos-de-uso', name: 'TermosDeUso', component: TermosDeUso },
   { path: '/atendimento/:id', name: 'Atendimento', component: Atendimento },
+  { path: '/pagar-agendamento/:id', name: 'PagamentoAgendamento', component: PagamentoAgendamento },
   { path: '/:slug', name: 'PublicPage', component: PublicPage },
 ]
 

--- a/src/views/PagamentoAgendamento.vue
+++ b/src/views/PagamentoAgendamento.vue
@@ -1,0 +1,72 @@
+<template>
+  <Navbar />
+  <section class="min-h-screen flex items-center justify-center bg-gray-100 px-4">
+    <div class="bg-white p-8 rounded-lg shadow w-full max-w-md space-y-4 text-center" v-if="profile && service">
+      <img src="/logo_pix.png" alt="Pix" class="mx-auto w-44 h-auto" />
+      <img v-if="pixQrCode" :src="pixQrCode" alt="QR Code Pix" class="mx-auto w-40 h-auto" />
+      <p class="font-semibold">Código de pagamento</p>
+      <input type="text" v-model="pixCode" readonly class="w-full px-4 py-2 border rounded-md text-center" />
+      <p class="font-semibold">Valor do pagamento</p>
+      <p class="text-lg font-semibold">{{ formatPrice(service.price) }}</p>
+      <p class="text-sm text-gray-600">Após o pagamento envie o comprovante para {{ profile.whatsapp }}</p>
+    </div>
+    <div v-else class="text-gray-500">Carregando...</div>
+  </section>
+  <Footer />
+</template>
+
+<script>
+import Navbar from '../components/Navbar.vue'
+import Footer from '../components/Footer.vue'
+import { supabase } from '../supabase'
+import { generatePixPayload } from '../utils/pix'
+
+export default {
+  name: 'PagamentoAgendamento',
+  components: { Navbar, Footer },
+  data() {
+    return {
+      profile: null,
+      appointment: null,
+      service: null,
+      pixCode: '',
+      pixQrCode: ''
+    }
+  },
+  methods: {
+    formatPrice(value) {
+      if (value === null || value === undefined || value === '') return ''
+      return Number(value).toLocaleString('pt-BR', {
+        style: 'currency',
+        currency: 'BRL'
+      })
+    },
+    generatePix() {
+      if (!this.profile || !this.service) return
+      const payload = generatePixPayload({
+        key: this.profile.pix_key,
+        name: this.profile.business_name,
+        amount: String(this.service.price)
+      })
+      this.pixCode = payload
+      this.pixQrCode =
+        'https://chart.googleapis.com/chart?cht=qr&chs=200x200&chl=' +
+        encodeURIComponent(payload)
+    }
+  },
+  async mounted() {
+    const id = this.$route.params.id
+    const { data: appt } = await supabase
+      .from('appointments')
+      .select('*, service:services(price), profile:profiles(pix_key,business_name,whatsapp)')
+      .eq('id', id)
+      .single()
+    if (appt) {
+      this.appointment = appt
+      this.service = appt.service
+      this.profile = appt.profile
+      this.generatePix()
+    }
+  }
+}
+</script>

--- a/supabase/schemas/023_add_confirmed_to_appointments.sql
+++ b/supabase/schemas/023_add_confirmed_to_appointments.sql
@@ -1,0 +1,2 @@
+alter table appointments add column if not exists confirmed boolean default true;
+alter table appointments add column if not exists from_site boolean default false;


### PR DESCRIPTION
## Summary
- add SQL migration to track appointment confirmation and origin
- color events red when unconfirmed and allow payment confirmation
- expose confirm button in appointment details
- add public page scheduling modal with date selection
- create payment page generating Pix code
- route for new payment page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd040a4408320bd2a12ce59853625