### PR TITLE
Fix pix payment page formatting

### DIFF
--- a/src/views/PagamentoAgendamento.vue
+++ b/src/views/PagamentoAgendamento.vue
@@ -1,18 +1,20 @@
 <template>
-  <Navbar />
-  <section class="min-h-screen flex items-center justify-center bg-gray-100 px-4">
-    <div class="bg-white p-8 rounded-lg shadow w-full max-w-md space-y-4 text-center" v-if="profile && service">
-      <img src="/logo_pix.png" alt="Pix" class="mx-auto w-44 h-auto" />
-      <img v-if="pixQrCode" :src="pixQrCode" alt="QR Code Pix" class="mx-auto w-40 h-auto" />
-      <p class="font-semibold">Código de pagamento</p>
-      <input type="text" v-model="pixCode" readonly class="w-full px-4 py-2 border rounded-md text-center" />
-      <p class="font-semibold">Valor do pagamento</p>
-      <p class="text-lg font-semibold">{{ formatPrice(service.price) }}</p>
-      <p class="text-sm text-gray-600">Após o pagamento envie o comprovante para {{ profile.whatsapp }}</p>
-    </div>
-    <div v-else class="text-gray-500">Carregando...</div>
-  </section>
-  <Footer />
+  <div class="flex flex-col min-h-screen">
+    <Navbar />
+    <section class="flex-1 flex items-center justify-center bg-gray-100 px-4">
+      <div class="bg-white p-8 rounded-lg shadow w-full max-w-md space-y-4 text-center" v-if="profile && service">
+        <img src="/logo_pix.png" alt="Pix" class="mx-auto w-44 h-auto" />
+        <img v-if="pixQrCode" :src="pixQrCode" alt="QR Code Pix" class="mx-auto w-40 h-auto" />
+        <p class="font-semibold">Código de pagamento</p>
+        <input type="text" v-model="pixCode" readonly class="w-full px-4 py-2 border rounded-md text-center" />
+        <p class="font-semibold">Valor do pagamento</p>
+        <p class="text-lg font-semibold">{{ formatPrice(service.price) }}</p>
+        <p class="text-sm text-gray-600">Após o pagamento envie o comprovante para {{ phoneMask(profile.whatsapp) }}</p>
+      </div>
+      <div v-else class="text-gray-500">Carregando...</div>
+    </section>
+    <Footer />
+  </div>
 </template>
 
 <script>
@@ -20,6 +22,7 @@ import Navbar from '../components/Navbar.vue'
 import Footer from '../components/Footer.vue'
 import { supabase } from '../supabase'
 import { generatePixPayload } from '../utils/pix'
+import { phoneMask } from '../utils/phone'
 
 export default {
   name: 'PagamentoAgendamento',
@@ -34,6 +37,7 @@ export default {
     }
   },
   methods: {
+    phoneMask,
     formatPrice(value) {
       if (value === null || value === undefined || value === '') return ''
       return Number(value).toLocaleString('pt-BR', {
@@ -50,7 +54,7 @@ export default {
       })
       this.pixCode = payload
       this.pixQrCode =
-        'https://chart.googleapis.com/chart?cht=qr&chs=200x200&chl=' +
+        'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=' +
         encodeURIComponent(payload)
     }
   },

--- a/src/views/PagamentoPlus.vue
+++ b/src/views/PagamentoPlus.vue
@@ -161,9 +161,9 @@ export default {
         amount: this.pixAmount
       })
       this.pixCode = payload
-      // Usa a API de charts do Google para gerar a imagem do QR Code
+      // Gera o QR Code usando um serviço de API público
       this.pixQrCode =
-        'https://chart.googleapis.com/chart?cht=qr&chs=200x200&chl=' +
+        'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=' +
         encodeURIComponent(payload)
     }
   }


### PR DESCRIPTION
## Summary
- center the pix payment page content
- display formatted whatsapp phone
- switch QR code generation to use qrserver API

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd73a92048320a377634378a1cc46