### PR TITLE
Highlight unpaid site bookings

### DIFF
--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -34,6 +34,7 @@
             v-for="appt in getAppointmentsForDay(day)"
             :key="appt.id"
             class="text-xs truncate cursor-pointer"
+            :class="appt.from_site && !appt.confirmed ? 'text-red-600' : ''"
             @click="$emit('select', appt)"
           >
             {{ addHoursToTime(appt.time) }} - {{ getClientName(appt.client_id) }}

--- a/src/components/WeekView.vue
+++ b/src/components/WeekView.vue
@@ -41,9 +41,9 @@
           v-for="event in events"
           :key="event.id"
           class="absolute text-white rounded px-2 py-1 event cursor-pointer"
-          :class="event.appointment.confirmed ? 'bg-blue-500' : 'bg-red-500'"
+          :class="event.appointment.from_site && !event.appointment.confirmed ? 'bg-red-500' : 'bg-blue-500'"
           :style="getEventStyle(event)"
-          :title="event.appointment.confirmed ? '' : 'pendente confirmação de pagamento'"
+          :title="event.appointment.from_site && !event.appointment.confirmed ? 'pendente confirmação de pagamento' : ''"
           @click="$emit('select', event.appointment)"
         >
           {{ event.title }} - {{ event.startTime }}

--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -131,6 +131,7 @@
                 v-if="selectedAppointment && selectedAppointment.from_site && !selectedAppointment.confirmed"
                 class="mb-4 text-center"
               >
+                <h4 class="font-medium mb-2">Ações Financeiras</h4>
                 <button @click="confirmPayment" class="btn btn-primary">
                   Confirmar pagamento
                 </button>
@@ -188,7 +189,14 @@
                 </tr>
               </thead>
               <tbody>
-                <tr v-for="appointment in processedAppointments" :key="appointment.id" class="border-b last:border-b-0">
+                <tr
+                  v-for="appointment in processedAppointments"
+                  :key="appointment.id"
+                  :class="[
+                    'border-b last:border-b-0',
+                    appointment.from_site && !appointment.confirmed ? 'text-red-600' : ''
+                  ]"
+                >
                   <td class="px-4 py-2">{{ formatDateBR(appointment.date) }} {{ addHoursToTime(appointment.time) }}</td>
                   <td class="px-4 py-2">{{ getClientName(appointment.client_id) }}</td>
                   <td class="px-4 py-2">{{ getServiceName(appointment.service_id) }}</td>


### PR DESCRIPTION
## Summary
- mark table rows red for unpaid bookings from site
- add "Ações Financeiras" section in appointment modal
- highlight unpaid site bookings on calendar and week views

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685bd7f3e3108320886cebfe06010bca