### PR TITLE
Highlight pending payment appointments

### DIFF
--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -206,7 +206,14 @@
               </tr>
             </thead>
             <tbody>
-              <tr v-for="a in clientAppointments" :key="a.id" class="border-b last:border-b-0">
+              <tr
+                v-for="a in clientAppointments"
+                :key="a.id"
+                :class="[
+                  'border-b last:border-b-0',
+                  a.from_site && !a.confirmed ? 'text-red-600' : ''
+                ]"
+              >
                 <td class="px-4 py-2">{{ formatDateBR(a.date) }} {{ addHoursToTime(a.time) }}</td>
                 <td class="px-4 py-2">{{ getServiceName(a.service_id) }}</td>
                 <td class="px-4 py-2 text-right space-x-2">


### PR DESCRIPTION
## Summary
- mark appointments awaiting payment confirmation in the client detail modal

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bdcad8dd0832093a0decef81611fe