### PR TITLE
Ajustes de alinhamento e destaque no cadastro de clientes

### DIFF
--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -132,7 +132,7 @@
                 class="mt-4"
               >
                 <h4 class="font-medium mb-2">Ações Financeiras</h4>
-                <div class="flex flex-wrap justify-center gap-2">
+                <div class="flex flex-wrap justify-start gap-2">
                   <button @click="confirmPayment" class="btn btn-primary">
                     Confirmar pagamento
                   </button>
@@ -140,7 +140,7 @@
               </div>
               <div class="mt-4">
                 <h4 class="font-medium mb-2">Ações de atendimento</h4>
-                <div class="flex flex-wrap justify-center gap-2">
+                <div class="flex flex-wrap justify-start gap-2">
                   <button @click="sendConfirmationWhatsApp" class="btn btn-success">Enviar confirmação</button>
                   <button @click="cancelAppointment" class="btn btn-warning">Desmarcou</button>
                   <button @click="markNoShow" class="btn btn-secondary">Faltou</button>
@@ -150,7 +150,7 @@
 
               <div class="mt-4">
                 <h4 class="font-medium mb-2">Ações de cadastro</h4>
-                <div class="flex flex-wrap justify-center gap-2">
+                <div class="flex flex-wrap justify-start gap-2">
                   <button @click="editFromDetails" class="btn">Editar</button>
                   <button @click="handleDeleteAppointment(selectedAppointment.id)" class="btn btn-danger">Excluir</button>
                 </div>

--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -211,10 +211,16 @@
                 :key="a.id"
                 :class="[
                   'border-b last:border-b-0',
-                  a.from_site && !a.confirmed ? 'text-red-600' : ''
+                  a.from_site && !a.confirmed ? 'ring-2 ring-red-500 rounded' : ''
                 ]"
               >
-                <td class="px-4 py-2">{{ formatDateBR(a.date) }} {{ addHoursToTime(a.time) }}</td>
+                <td class="px-4 py-2">
+                  {{ formatDateBR(a.date) }} {{ addHoursToTime(a.time) }}
+                  <span
+                    v-if="a.from_site && !a.confirmed"
+                    class="block text-xs text-red-600"
+                  >pendente confirmação de pagamento</span>
+                </td>
                 <td class="px-4 py-2">{{ getServiceName(a.service_id) }}</td>
                 <td class="px-4 py-2 text-right space-x-2">
                   <router-link :to="{ path: '/agendamentos', query: { edit: a.id } }" class="btn btn-sm">Editar</router-link>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -209,7 +209,7 @@
           <template #actions>
             <div class="mt-4">
               <h4 class="font-medium mb-2">Ações de atendimento</h4>
-              <div class="flex flex-wrap justify-center gap-2">
+              <div class="flex flex-wrap justify-start gap-2">
                 <button @click="sendConfirmationWhatsApp" class="btn btn-success">Enviar confirmação</button>
                 <button @click="cancelAppointment" class="btn btn-warning">Desmarcou</button>
                 <button @click="markNoShow" class="btn btn-secondary">Faltou</button>
@@ -219,7 +219,7 @@
 
             <div class="mt-4">
               <h4 class="font-medium mb-2">Ações de cadastro</h4>
-              <div class="flex flex-wrap justify-center gap-2">
+              <div class="flex flex-wrap justify-start gap-2">
                 <button @click="editFromDetails" class="btn">Editar</button>
                 <button @click="handleDeleteAppointment(selectedAppointment.id)" class="btn btn-danger">Excluir</button>
                 <button @click="closeDetails" class="px-4 py-2 rounded border">Fechar</button>


### PR DESCRIPTION
## Resumo
- altera para alinhamento à esquerda dos botões nas ações do modal de detalhes
- destaca agendamentos pendentes de pagamento no cadastro de clientes com borda vermelha e aviso

## Testes
- `npm run build` *(falha: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bde44783083208f57cabc4ef33cf4