### PR TITLE
Add external repo deployment step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,3 +30,12 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           cname: www.agendazen.com.br
+
+      - name: Copy files to agenda-zen repository
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.PERSONAL_TOKEN }}
+          external_repository: agenda-zen/agenda-zen
+          publish_branch: gh-pages
+          publish_dir: ./dist
+          cname: www.agendazen.com.br


### PR DESCRIPTION
## Summary
- update GitHub Actions deploy workflow to also copy the built site to `agenda-zen/agenda-zen` repository

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c71995ed8832e8866eee1f1f58e79