### PR TITLE
Add CPF field and footer updates

### DIFF
--- a/src/views/PagamentoAgendamento.vue
+++ b/src/views/PagamentoAgendamento.vue
@@ -20,6 +20,7 @@
       </div>
       <div v-else class="text-gray-500">Carregando...</div>
     </section>
+    <Footer />
   </div>
 </template>
 
@@ -28,9 +29,11 @@
 import { supabase } from '../supabase'
 import { generatePixPayload } from '../utils/pix'
 import { phoneMask } from '../utils/phone'
+import Footer from '../components/Footer.vue'
 
 export default {
   name: 'PagamentoAgendamento',
+  components: { Footer },
   data() {
     return {
       profile: null,

--- a/supabase/schemas/025_add_from_site_to_clients.sql
+++ b/supabase/schemas/025_add_from_site_to_clients.sql
@@ -1,0 +1,3 @@
+alter table clients add column if not exists from_site boolean default false;
+alter table clients add column if not exists pending_update boolean default false;
+


### PR DESCRIPTION
## Summary
- add footer on payment page
- require CPF when scheduling via public page
- avoid updating existing client when creating appointments
- mark new clients as created from site and pending update
- add database migration for new flags

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c754682248320a35a3148eb60e1b5