### PR TITLE
Enable anonymous site client registration

### DIFF
--- a/supabase/schemas/026_allow_public_clients.sql
+++ b/supabase/schemas/026_allow_public_clients.sql
@@ -1,0 +1,13 @@
+create policy "Anonymous site clients insert"
+  on clients
+  for insert
+  with check (
+    auth.role() = 'anon' and from_site = true
+  );
+
+create policy "Anonymous site clients read"
+  on clients
+  for select
+  using (
+    auth.role() = 'anon' and from_site = true
+  );


### PR DESCRIPTION
## Summary
- allow anonymous site users to insert and read client records

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7adf04fc8320889f6648c2b16025