### PR TITLE
Atualiza cliente ao agendar pelo site

### DIFF
--- a/src/views/PublicPage.vue
+++ b/src/views/PublicPage.vue
@@ -242,6 +242,19 @@ export default {
 
       if (existingClient) {
         clientId = existingClient.id
+        // Atualiza cadastro caso dados diferentes sejam informados
+        const { error: updateErr } = await supabase
+          .from('clients')
+          .update({
+            name: this.form.name,
+            email: this.form.email,
+            phone: this.form.phone,
+            cpf: this.form.cpf
+          })
+          .eq('id', clientId)
+        if (updateErr) {
+          console.error('Erro ao atualizar cliente:', updateErr.message)
+        }
       } else {
         const { data: newClient, error: clientErr } = await supabase
           .from('clients')


### PR DESCRIPTION
## Summary
- update client record with new data when scheduling through public page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7d007bc88320919ff7c71d33fbe8