### PR TITLE
Mark clients created via public site

### DIFF
--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -318,7 +318,9 @@ export default {
           complement: '',
           neighborhood: '',
           stateId: '',
-          cityId: ''
+          cityId: '',
+          from_site: false,
+          pending_update: false
         },
         states: [],
         cities: [],
@@ -394,14 +396,16 @@ export default {
           complement: client.complement,
           neighborhood: client.neighborhood,
           stateId: client.state_id,
-          cityId: client.city_id
+          cityId: client.city_id,
+          from_site: client.from_site,
+          pending_update: client.pending_update
         }
         this.originalForm = { ...this.form }
         await this.fetchClientAppointments()
         await this.fetchClientHistory()
       } else {
         this.editingId = null
-        this.form = { name: '', email: '', phone: '', birthdate: '', cpf: '', cep: '', street: '', number: '', complement: '', neighborhood: '', stateId: '', cityId: '' }
+        this.form = { name: '', email: '', phone: '', birthdate: '', cpf: '', cep: '', street: '', number: '', complement: '', neighborhood: '', stateId: '', cityId: '', from_site: false, pending_update: false }
         this.originalForm = { ...this.form }
         this.clientAppointments = []
         this.history = []
@@ -418,7 +422,7 @@ export default {
       this.showModal = false
       this.modalMode = 'new'
       this.editingId = null
-      this.form = { name: '', email: '', phone: '', birthdate: '', cpf: '', cep: '', street: '', number: '', complement: '', neighborhood: '', stateId: '', cityId: '' }
+      this.form = { name: '', email: '', phone: '', birthdate: '', cpf: '', cep: '', street: '', number: '', complement: '', neighborhood: '', stateId: '', cityId: '', from_site: false, pending_update: false }
       this.activeTab = 'cadastro'
       this.clientAppointments = []
       this.history = []
@@ -457,9 +461,8 @@ export default {
             number: this.form.number,
             complement: this.form.complement,
             neighborhood: this.form.neighborhood,
-            state_id: this.form.stateId,
+          state_id: this.form.stateId,
           city_id: this.form.cityId,
-          from_site: false,
           pending_update: false
         })
           .eq('id', this.editingId)
@@ -480,9 +483,11 @@ export default {
             number: this.form.number,
             complement: this.form.complement,
             neighborhood: this.form.neighborhood,
-            state_id: this.form.stateId,
+          state_id: this.form.stateId,
           city_id: this.form.cityId,
-          user_id: this.userId
+          user_id: this.userId,
+          from_site: this.form.from_site,
+          pending_update: this.form.pending_update
         })
           .select()
           .single())

--- a/src/views/PublicPage.vue
+++ b/src/views/PublicPage.vue
@@ -249,7 +249,9 @@ export default {
             name: this.form.name,
             email: this.form.email,
             phone: this.form.phone,
-            cpf: this.form.cpf
+            cpf: this.form.cpf,
+            from_site: true,
+            pending_update: true
           })
           .eq('id', clientId)
         if (updateErr) {


### PR DESCRIPTION
## Summary
- keep `from_site` flag while editing clients
- ensure form stores `from_site` and `pending_update`
- flag existing clients when scheduling from the public page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7e225a348320818efe70187db8a9