### PR TITLE
Add payment field and recurring appointments

### DIFF
--- a/src/utils/datetime.js
+++ b/src/utils/datetime.js
@@ -26,3 +26,14 @@ export function addHoursToTime(timeStr, hours = 1) {
   const newM = String(date.getMinutes()).padStart(2, '0')
   return `${newH}:${newM}`
 }
+
+export function addDays(dateStr, days = 1) {
+  if (!dateStr) return ''
+  const [y, m, d] = dateStr.split('-').map(Number)
+  const date = new Date(y, m - 1, d)
+  date.setDate(date.getDate() + days)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}

--- a/supabase/schemas/029_add_paid_to_appointments.sql
+++ b/supabase/schemas/029_add_paid_to_appointments.sql
@@ -1,0 +1,1 @@
+alter table appointments add column if not exists paid boolean default false;


### PR DESCRIPTION
## Summary
- add DB script for `paid` field
- support new `addDays` helper
- allow setting if appointment was paid
- create recurring appointments for packages

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c95b3757483209ab24b258fc61bd0