### PR TITLE
Fix client page null phone error

### DIFF
--- a/src/utils/phone.js
+++ b/src/utils/phone.js
@@ -1,5 +1,5 @@
 export function phoneMask(value) {
-  const digits = value.replace(/\D/g, '').slice(0, 11)
+  const digits = String(value ?? '').replace(/\D/g, '').slice(0, 11)
   const ddd = digits.slice(0, 2)
 
   if (digits.length <= 2) {
@@ -23,5 +23,5 @@ export function phoneMask(value) {
 }
 
 export function digitsOnly(value) {
-  return value.replace(/\D/g, '')
+  return String(value ?? '').replace(/\D/g, '')
 }

--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -616,7 +616,7 @@ export default {
       this.fetchCitiesList()
     },
     'form.cep'(val) {
-      const digits = val.replace(/\D/g, '')
+      const digits = (val || '').toString().replace(/\D/g, '')
       if (digits.length === 8) {
         this.fillAddressByCep()
       }


### PR DESCRIPTION
## Summary
- handle null values in phone helper functions
- avoid crash on empty CEP watcher

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9d9824048320a83682db70d6cd5e