### PR TITLE
Add despesas feature to financial center

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -86,6 +86,15 @@
           </router-link>
         </div>
         <div class="space-y-2">
+          <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Centro Financeiro</h3>
+          <router-link to="/despesas" class="flex items-center text-gray-700 hover:text-blue-600">
+            <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm0 8c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2zm0-4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z" />
+            </svg>
+            <span>Despesas</span>
+          </router-link>
+        </div>
+        <div class="space-y-2">
           <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Conta</h3>
           <router-link to="/configuracao" class="flex items-center text-gray-700 hover:text-blue-600">
             <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -26,6 +26,7 @@ import PagamentoPlus from '../views/PagamentoPlus.vue'
 import PagamentoAgendamento from '../views/PagamentoAgendamento.vue'
 import Confirmacao from '../views/Confirmacao.vue'
 import LinkExpirado from '../views/LinkExpirado.vue'
+import Despesas from '../views/Despesas.vue'
 import { supabase } from '../supabase'
 
 
@@ -43,6 +44,7 @@ const routes = [
   { path: '/salas', name: 'Salas', component: Salas },
   { path: '/agendamentos', name: 'Agendamentos', component: Agendamentos },
   { path: '/comprovantes', name: 'Comprovantes', component: Comprovantes },
+  { path: '/despesas', name: 'Despesas', component: Despesas },
   { path: '/templates', name: 'Templates', component: Templates },
   { path: '/usuarios', name: 'Usuarios', component: Usuarios },
   { path: '/minha-assinatura', name: 'MinhaAssinatura', component: MinhaAssinatura },

--- a/supabase/schemas/031_create_expenses.sql
+++ b/supabase/schemas/031_create_expenses.sql
@@ -1,0 +1,16 @@
+create table if not exists expenses (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references auth.users(id) on delete cascade,
+  title text not null,
+  amount numeric not null,
+  due_date date not null,
+  paid_date date,
+  fixed boolean default false,
+  repeat_months integer,
+  created_at timestamp with time zone default now()
+);
+
+alter table expenses enable row level security;
+
+create policy "Users can manage own expenses" on expenses
+  for all using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add SQL schema for `expenses`
- add Despesas page for listing and creating expenses
- register `/despesas` route
- update sidebar with Centro Financeiro section

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca1516adc8320a5d7201a6146a6af