### PR TITLE
Move Despesas under finance menu

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -65,7 +65,7 @@
             </router-link>
           </div>
 
-          <!-- Centro Financeiro (comprovantes e templates) -->
+          <!-- Centro Financeiro -->
           <div class="space-y-2">
             <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Centro Financeiro</h3>
             <router-link to="/comprovantes" class="flex items-center text-gray-700 hover:text-blue-600">
@@ -79,6 +79,12 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4h16v4H4V4zm0 6h16v10H4V10z" />
               </svg>
               <span>Templates</span>
+            </router-link>
+            <router-link to="/despesas" class="flex items-center text-gray-700 hover:text-blue-600">
+              <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm0 8c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2zm0-4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z" />
+              </svg>
+              <span>Despesas</span>
             </router-link>
           </div>
 
@@ -119,16 +125,6 @@
             </router-link>
           </div>
 
-          <!-- Centro Financeiro (despesas) -->
-          <div class="space-y-2">
-            <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Centro Financeiro</h3>
-            <router-link to="/despesas" class="flex items-center text-gray-700 hover:text-blue-600">
-              <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm0 8c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2zm0-4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z" />
-              </svg>
-              <span>Despesas</span>
-            </router-link>
-          </div>
         </nav>
     </aside>
   </div>


### PR DESCRIPTION
## Summary
- group `Despesas` item under the single **Centro Financeiro** section
- remove the duplicate empty menu section

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca5d05cb08320a2e757bbd2dfb61f