### PR TITLE
Implement expense enhancements

### DIFF
--- a/src/utils/datetime.js
+++ b/src/utils/datetime.js
@@ -37,3 +37,14 @@ export function addDays(dateStr, days = 1) {
   const day = String(date.getDate()).padStart(2, '0')
   return `${year}-${month}-${day}`
 }
+
+export function addMonths(dateStr, months = 1) {
+  if (!dateStr) return ''
+  const [y, m, d] = dateStr.split('-').map(Number)
+  const date = new Date(y, m - 1, d)
+  date.setMonth(date.getMonth() + months)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -30,3 +30,19 @@ export function formatDateBR(dateStr) {
   const [year, month, day] = parts
   return `${day.padStart(2, '0')}/${month.padStart(2, '0')}/${year}`
 }
+
+export function currencyMask(value) {
+  const digits = String(value ?? '').replace(/\D/g, '')
+  if (!digits) return ''
+  const number = parseInt(digits, 10) / 100
+  return number.toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL'
+  })
+}
+
+export function currencyToNumber(value) {
+  const digits = String(value ?? '').replace(/\D/g, '')
+  if (!digits) return 0
+  return parseInt(digits, 10) / 100
+}


### PR DESCRIPTION
## Summary
- add helpers for currency masking and addMonths
- support expense repetition by months when fixed
- format amount field as BRL and add editing
- allow editing and replicating expenses in Despesas view

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca866ba308320bb067f3baccebd2d