### PR TITLE
Fix missing import for addHoursToTime

### DIFF
--- a/src/views/NovoAgendamento.vue
+++ b/src/views/NovoAgendamento.vue
@@ -73,7 +73,7 @@ import HeaderUser from '../components/HeaderUser.vue'
 import { supabase } from '../supabase'
 import { sendAppointmentEmail } from '../utils/email'
 import { formatDateBR } from '../utils/format'
-import { addDays } from '../utils/datetime'
+import { addHoursToTime, addDays } from '../utils/datetime'
 
 export default {
   name: 'NovoAgendamento',


### PR DESCRIPTION
## Summary
- fix missing `addHoursToTime` import in `NovoAgendamento.vue`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d27feea508320b6bc7b43dc703ac7