### PR TITLE
Add reports for appointments and receipts

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -91,6 +91,21 @@
           <!-- Relatórios -->
           <div class="space-y-2">
             <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Relatórios</h3>
+            <router-link to="/relatorio-agendamentos" class="flex items-center text-gray-700 hover:text-blue-600">
+              <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2" stroke-width="2"/>
+                <line x1="16" y1="2" x2="16" y2="6" stroke-width="2"/>
+                <line x1="8" y1="2" x2="8" y2="6" stroke-width="2"/>
+                <line x1="3" y1="10" x2="21" y2="10" stroke-width="2"/>
+              </svg>
+              <span>Agendamentos</span>
+            </router-link>
+            <router-link to="/recebimento" class="flex items-center text-gray-700 hover:text-blue-600">
+              <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm0 8c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2zm0-4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z" />
+              </svg>
+              <span>Recebimento</span>
+            </router-link>
             <router-link to="/faturamento" class="flex items-center text-gray-700 hover:text-blue-600">
               <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3v18h18M9 17v-4M13 17v-8M17 17V7" />

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -20,6 +20,8 @@ import Templates from '../views/Templates.vue'
 import Contato from '../views/Contato.vue'
 import MinhaAssinatura from '../views/MinhaAssinatura.vue'
 import Faturamento from '../views/Faturamento.vue'
+import RelatorioAgendamentos from '../views/RelatorioAgendamentos.vue'
+import Recebimento from '../views/Recebimento.vue'
 import Faq from '../views/Faq.vue'
 import PoliticaPrivacidade from '../views/PoliticaPrivacidade.vue'
 import TermosDeUso from '../views/TermosDeUso.vue'
@@ -51,6 +53,8 @@ const routes = [
   { path: '/usuarios', name: 'Usuarios', component: Usuarios },
   { path: '/minha-assinatura', name: 'MinhaAssinatura', component: MinhaAssinatura },
   { path: '/assinatura-plus', name: 'PagamentoPlus', component: PagamentoPlus },
+  { path: '/relatorio-agendamentos', name: 'RelatorioAgendamentos', component: RelatorioAgendamentos },
+  { path: '/recebimento', name: 'Recebimento', component: Recebimento },
   { path: '/faturamento', name: 'Faturamento', component: Faturamento },
   { path: '/buscar', name: 'SearchProfiles', component: SearchProfiles },
   { path: '/planos', name: 'Planos', component: Planos },

--- a/src/views/Recebimento.vue
+++ b/src/views/Recebimento.vue
@@ -1,0 +1,158 @@
+<template>
+  <div class="min-h-screen flex bg-gray-100 relative">
+    <Sidebar :is-open="sidebarOpen" @close="sidebarOpen = false" />
+    <main class="flex-1 p-4 md:p-8 space-y-6">
+      <div v-if="!sidebarOpen" class="flex items-center mb-4">
+        <button @click="sidebarOpen = true" class="text-gray-600 focus:outline-none">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+      <HeaderUser title="Relatório de Recebimento" />
+
+      <section class="bg-white p-4 rounded-lg shadow space-y-4">
+        <div class="grid grid-cols-1 md:grid-cols-5 gap-4 items-end">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Cliente</label>
+            <select v-model="clientId" class="w-full px-4 py-2 border rounded-md">
+              <option value="">Todos</option>
+              <option v-for="c in clients" :key="c.id" :value="c.id">{{ c.name }}</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Serviço</label>
+            <select v-model="serviceId" class="w-full px-4 py-2 border rounded-md">
+              <option value="">Todos</option>
+              <option v-for="s in services" :key="s.id" :value="s.id">{{ s.name }}</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">De</label>
+            <input type="date" v-model="filterStart" class="w-full px-4 py-2 border rounded-md" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Até</label>
+            <input type="date" v-model="filterEnd" class="w-full px-4 py-2 border rounded-md" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Agendamentos</label>
+            <select v-model="paidFilter" class="w-full px-4 py-2 border rounded-md">
+              <option value="all">Todos</option>
+              <option value="paid">Pagos</option>
+              <option value="open">Em aberto</option>
+            </select>
+          </div>
+        </div>
+        <div class="flex justify-end">
+          <button @click="fetchAppointments" class="btn">Aplicar</button>
+        </div>
+      </section>
+
+      <section class="bg-white p-4 rounded-lg shadow">
+        <div class="overflow-x-auto">
+          <table class="min-w-full text-left">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="px-4 py-2 font-medium text-gray-700">Data/Horário do Atendimento</th>
+                <th class="px-4 py-2 font-medium text-gray-700">Serviço</th>
+                <th class="px-4 py-2 font-medium text-gray-700">Valor</th>
+                <th class="px-4 py-2 font-medium text-gray-700">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="a in appointments" :key="a.id" class="border-b last:border-b-0">
+                <td class="px-4 py-2">{{ formatDateBR(a.date) }} {{ addHoursToTime(a.time) }}</td>
+                <td class="px-4 py-2">{{ getServiceName(a.service_id) }}</td>
+                <td class="px-4 py-2">{{ formatPrice(getServicePrice(a.service_id)) }}</td>
+                <td class="px-4 py-2">{{ a.paid ? 'Pago' : 'pagamento em aberto' }}</td>
+              </tr>
+              <tr v-if="appointments.length === 0">
+                <td colspan="4" class="px-4 py-6 text-center text-gray-500">Nenhum registro</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  </div>
+</template>
+
+<script>
+import Sidebar from '../components/Sidebar.vue'
+import HeaderUser from '../components/HeaderUser.vue'
+import { supabase } from '../supabase'
+import { formatDateBR } from '../utils/format'
+import { addHoursToTime } from '../utils/datetime'
+
+export default {
+  name: 'Recebimento',
+  components: { Sidebar, HeaderUser },
+  data() {
+    return {
+      sidebarOpen: window.innerWidth >= 768,
+      userId: null,
+      clients: [],
+      services: [],
+      appointments: [],
+      clientId: '',
+      serviceId: '',
+      filterStart: '',
+      filterEnd: '',
+      paidFilter: 'all'
+    }
+  },
+  methods: {
+    formatDateBR,
+    addHoursToTime,
+    formatPrice(value) {
+      return Number(value).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })
+    },
+    getServiceName(id) {
+      const s = this.services.find(sv => sv.id === id)
+      return s ? s.name : ''
+    },
+    getServicePrice(id) {
+      const s = this.services.find(sv => sv.id === id)
+      return s ? s.price || 0 : 0
+    },
+    async fetchAppointments() {
+      if (!this.filterStart || !this.filterEnd) return
+      let query = supabase
+        .from('appointments')
+        .select()
+        .eq('user_id', this.userId)
+        .gte('date', this.filterStart)
+        .lte('date', this.filterEnd)
+
+      if (this.clientId) query = query.eq('client_id', this.clientId)
+      if (this.serviceId) query = query.eq('service_id', this.serviceId)
+      if (this.paidFilter === 'paid') query = query.eq('paid', true)
+      else if (this.paidFilter === 'open') query = query.eq('paid', false)
+
+      const { data } = await query.order('date', { ascending: true }).order('time', { ascending: true })
+      this.appointments = data || []
+    }
+  },
+  async mounted() {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      this.$router.push('/login')
+      return
+    }
+    this.userId = user.id
+
+    const { data: clients } = await supabase.from('clients').select().eq('user_id', this.userId)
+    if (clients) this.clients = clients
+
+    const { data: services } = await supabase.from('services').select().eq('user_id', this.userId)
+    if (services) this.services = services
+
+    const today = new Date()
+    const firstDay = new Date(today.getFullYear(), today.getMonth(), 1)
+    this.filterStart = firstDay.toISOString().split('T')[0]
+    this.filterEnd = today.toISOString().split('T')[0]
+    this.fetchAppointments()
+  }
+}
+</script>

--- a/src/views/RelatorioAgendamentos.vue
+++ b/src/views/RelatorioAgendamentos.vue
@@ -1,0 +1,167 @@
+<template>
+  <div class="min-h-screen flex bg-gray-100 relative">
+    <Sidebar :is-open="sidebarOpen" @close="sidebarOpen = false" />
+    <main class="flex-1 p-4 md:p-8 space-y-6">
+      <div v-if="!sidebarOpen" class="flex items-center mb-4">
+        <button @click="sidebarOpen = true" class="text-gray-600 focus:outline-none">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+      <HeaderUser title="Relatório de Agendamentos" />
+
+      <section class="bg-white p-4 rounded-lg shadow space-y-4">
+        <div class="flex flex-col md:flex-row md:items-end md:space-x-4 space-y-4 md:space-y-0">
+          <div class="flex flex-wrap gap-2">
+            <button class="btn btn-sm" @click="setPeriodo('dia')">Dia</button>
+            <button class="btn btn-sm" @click="setPeriodo('semana')">Semana</button>
+            <button class="btn btn-sm" @click="setPeriodo('mes')">Mês</button>
+          </div>
+          <div class="flex space-x-2">
+            <input type="date" v-model="filterStart" class="border px-3 py-2 rounded" />
+            <input type="date" v-model="filterEnd" class="border px-3 py-2 rounded" />
+          </div>
+          <div>
+            <select v-model="clientId" class="border px-3 py-2 rounded">
+              <option value="">Todos os clientes</option>
+              <option v-for="c in clients" :key="c.id" :value="c.id">{{ c.name }}</option>
+            </select>
+          </div>
+          <button @click="fetchAppointments" class="btn">Aplicar</button>
+        </div>
+      </section>
+
+      <section class="bg-white p-4 rounded-lg shadow">
+        <div class="overflow-x-auto">
+          <table class="min-w-full text-left">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="px-4 py-2 font-medium text-gray-700">Data/Horário do Atendimento</th>
+                <th class="px-4 py-2 font-medium text-gray-700">Paciente</th>
+                <th class="px-4 py-2 font-medium text-gray-700">Serviço</th>
+                <th class="px-4 py-2 font-medium text-gray-700">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="a in appointments" :key="a.id" class="border-b last:border-b-0">
+                <td class="px-4 py-2">{{ formatDateBR(a.date) }} {{ addHoursToTime(a.time) }}</td>
+                <td class="px-4 py-2">{{ getClientName(a.client_id) }}</td>
+                <td class="px-4 py-2">{{ getServiceName(a.service_id) }}</td>
+                <td class="px-4 py-2">{{ getStatusLabel(a) }}</td>
+              </tr>
+              <tr v-if="appointments.length === 0">
+                <td colspan="4" class="px-4 py-6 text-center text-gray-500">Nenhum agendamento</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  </div>
+</template>
+
+<script>
+import Sidebar from '../components/Sidebar.vue'
+import HeaderUser from '../components/HeaderUser.vue'
+import { supabase } from '../supabase'
+import { formatDateBR } from '../utils/format'
+import { addHoursToTime } from '../utils/datetime'
+
+export default {
+  name: 'RelatorioAgendamentos',
+  components: { Sidebar, HeaderUser },
+  data() {
+    return {
+      sidebarOpen: window.innerWidth >= 768,
+      userId: null,
+      clients: [],
+      services: [],
+      appointments: [],
+      filterStart: '',
+      filterEnd: '',
+      clientId: ''
+    }
+  },
+  methods: {
+    formatDateBR,
+    addHoursToTime,
+    setPeriodo(tipo) {
+      const today = new Date()
+      let start = new Date(today)
+      let end = new Date(today)
+      if (tipo === 'semana') {
+        const day = today.getDay()
+        const diff = day === 0 ? 6 : day - 1
+        start.setDate(today.getDate() - diff)
+        end = new Date(start)
+        end.setDate(start.getDate() + 6)
+      } else if (tipo === 'mes') {
+        start = new Date(today.getFullYear(), today.getMonth(), 1)
+        end = new Date(today.getFullYear(), today.getMonth() + 1, 0)
+      }
+      this.filterStart = start.toISOString().split('T')[0]
+      this.filterEnd = end.toISOString().split('T')[0]
+      this.fetchAppointments()
+    },
+    getClientName(id) {
+      const c = this.clients.find(cl => cl.id === id)
+      return c ? c.name : ''
+    },
+    getServiceName(id) {
+      const s = this.services.find(sv => sv.id === id)
+      return s ? s.name : ''
+    },
+    getStatusLabel(appt) {
+      if (appt.status === 'completed') return 'atendimento realizado'
+      if (appt.status === 'no_show') return 'faltou'
+      return 'atendimento pendente'
+    },
+    async fetchAppointments() {
+      if (!this.filterStart || !this.filterEnd) return
+      let query = supabase
+        .from('appointments')
+        .select()
+        .eq('user_id', this.userId)
+        .gte('date', this.filterStart)
+        .lte('date', this.filterEnd)
+
+      if (this.clientId) {
+        query = query.eq('client_id', this.clientId)
+      }
+
+      const { data } = await query
+        .order('date', { ascending: true })
+        .order('time', { ascending: true })
+
+      this.appointments = data || []
+    }
+  },
+  async mounted() {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      this.$router.push('/login')
+      return
+    }
+    this.userId = user.id
+
+    const { data: clientData } = await supabase
+      .from('clients')
+      .select()
+      .eq('user_id', this.userId)
+    if (clientData) this.clients = clientData
+
+    const { data: serviceData } = await supabase
+      .from('services')
+      .select()
+      .eq('user_id', this.userId)
+    if (serviceData) this.services = serviceData
+
+    const today = new Date()
+    const dateStr = today.toISOString().split('T')[0]
+    this.filterStart = dateStr
+    this.filterEnd = dateStr
+    this.fetchAppointments()
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- add "Relatório de Agendamentos" page
- add "Relatório de Recebimento" page
- include new report routes in router
- expose menu items in sidebar

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d294d3454832091cbaaa41166831c