### PR TITLE
Adjust paid status handling

### DIFF
--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -153,7 +153,7 @@
           >
             <template #actions>
               <div
-                v-if="selectedAppointment && selectedAppointment.from_site && !selectedAppointment.confirmed"
+                v-if="selectedAppointment && selectedAppointment.from_site && !selectedAppointment.paid"
                 class="mt-4"
               >
                 <h4 class="font-medium mb-2">Ações Financeiras</h4>
@@ -663,7 +663,7 @@ export default {
       if (!appt) return
       const { data, error } = await supabase
         .from('appointments')
-        .update({ confirmed: true })
+        .update({ confirmed: true, paid: true })
         .eq('id', appt.id)
         .select()
         .single()


### PR DESCRIPTION
## Summary
- display financial actions when appointment is unpaid
- set `paid` to true when confirming payment

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d2b5fbf988320a1e1060f26829d72