### PR TITLE
Add n8n to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,36 @@ services:
     build: .
     ports:
       - "8080:80"
+
+  n8n:
+    image: n8nio/n8n
+    ports:
+      - "5678:5678"
+    environment:
+      - DB_TYPE=postgresdb
+      - DB_POSTGRESDB_HOST=${N8N_DB_HOST:-n8n-db}
+      - DB_POSTGRESDB_PORT=${N8N_DB_PORT:-5432}
+      - DB_POSTGRESDB_DATABASE=${N8N_DB_NAME:-n8n}
+      - DB_POSTGRESDB_USER=${N8N_DB_USER:-n8n}
+      - DB_POSTGRESDB_PASSWORD=${N8N_DB_PASSWORD:-n8n}
+      - N8N_BASIC_AUTH_ACTIVE=${N8N_BASIC_AUTH_ACTIVE:-true}
+      - N8N_BASIC_AUTH_USER=${N8N_BASIC_AUTH_USER:-admin}
+      - N8N_BASIC_AUTH_PASSWORD=${N8N_BASIC_AUTH_PASSWORD:-password}
+    volumes:
+      - n8n_data:/home/node/.n8n
+    depends_on:
+      - n8n-db
+
+  n8n-db:
+    image: postgres:14
+    restart: always
+    environment:
+      - POSTGRES_DB=${N8N_DB_NAME:-n8n}
+      - POSTGRES_USER=${N8N_DB_USER:-n8n}
+      - POSTGRES_PASSWORD=${N8N_DB_PASSWORD:-n8n}
+    volumes:
+      - n8n_db_data:/var/lib/postgresql/data
+
+volumes:
+  n8n_data:
+  n8n_db_data:


### PR DESCRIPTION
## Summary
- extend `docker-compose.yml` to include an n8n service backed by PostgreSQL
- use volumes for persistent storage and allow configuration via env vars

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685ddd2d8074832e9fabbd7d7346d89b