### PR TITLE
Fix services button layout

### DIFF
--- a/src/views/Servicos.vue
+++ b/src/views/Servicos.vue
@@ -51,7 +51,7 @@
                 <td class="px-4 py-2">{{ service.description }}</td>
                 <td class="px-4 py-2">{{ service.duration }} minutos</td>
                 <td class="px-4 py-2">{{ formatPrice(service.price) }}</td>
-                <td class="px-4 py-2 text-right space-x-2">
+                <td class="px-4 py-2 text-right space-x-2 whitespace-nowrap">
                   <button
                     @click="openModal(service)"
                     class="btn btn-sm"


### PR DESCRIPTION
## Summary
- keep action buttons on a single line in `Servicos.vue`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed7a043a083209c41f321f488b9d2