### PR TITLE
Add open sessions report

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -90,7 +90,13 @@
 
           <!-- Relatórios -->
           <div class="space-y-2">
-            <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Relatórios</h3>
+          <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Relatórios</h3>
+            <router-link to="/relatorio-em-aberto" class="flex items-center text-gray-700 hover:text-blue-600">
+              <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <span>Em Aberto</span>
+            </router-link>
             <router-link to="/relatorio-agendamentos" class="flex items-center text-gray-700 hover:text-blue-600">
               <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <rect x="3" y="4" width="18" height="18" rx="2" ry="2" stroke-width="2"/>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -22,6 +22,7 @@ import MinhaAssinatura from '../views/MinhaAssinatura.vue'
 import Faturamento from '../views/Faturamento.vue'
 import RelatorioAgendamentos from '../views/RelatorioAgendamentos.vue'
 import Recebimento from '../views/Recebimento.vue'
+import RelatorioEmAberto from '../views/RelatorioEmAberto.vue'
 import Faq from '../views/Faq.vue'
 import PoliticaPrivacidade from '../views/PoliticaPrivacidade.vue'
 import TermosDeUso from '../views/TermosDeUso.vue'
@@ -53,6 +54,7 @@ const routes = [
   { path: '/usuarios', name: 'Usuarios', component: Usuarios },
   { path: '/minha-assinatura', name: 'MinhaAssinatura', component: MinhaAssinatura },
   { path: '/assinatura-plus', name: 'PagamentoPlus', component: PagamentoPlus },
+  { path: '/relatorio-em-aberto', name: 'RelatorioEmAberto', component: RelatorioEmAberto },
   { path: '/relatorio-agendamentos', name: 'RelatorioAgendamentos', component: RelatorioAgendamentos },
   { path: '/recebimento', name: 'Recebimento', component: Recebimento },
   { path: '/faturamento', name: 'Faturamento', component: Faturamento },

--- a/src/views/RelatorioEmAberto.vue
+++ b/src/views/RelatorioEmAberto.vue
@@ -1,0 +1,142 @@
+<template>
+  <div class="min-h-screen flex bg-gray-100 relative">
+    <Sidebar :is-open="sidebarOpen" @close="sidebarOpen = false" />
+    <main class="flex-1 p-4 md:p-8 space-y-6">
+      <div v-if="!sidebarOpen" class="flex items-center mb-4">
+        <button @click="sidebarOpen = true" class="text-gray-600 focus:outline-none">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+      <HeaderUser title="Relatório Em Aberto" />
+
+      <section class="bg-white p-4 rounded-lg shadow space-y-4">
+        <div class="flex flex-col md:flex-row md:items-end md:space-x-4 space-y-4 md:space-y-0">
+          <div>
+            <select v-model="clientId" class="border px-3 py-2 rounded">
+              <option value="">Todos os clientes</option>
+              <option v-for="c in clients" :key="c.id" :value="c.id">{{ c.name }}</option>
+            </select>
+          </div>
+          <button @click="generateReport" class="btn">Aplicar</button>
+        </div>
+      </section>
+
+      <section class="bg-white p-4 rounded-lg shadow">
+        <div class="overflow-x-auto">
+          <table class="min-w-full text-left">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="px-4 py-2 font-medium text-gray-700">Cliente</th>
+                <th class="px-4 py-2 font-medium text-gray-700">Serviço</th>
+                <th class="px-4 py-2 font-medium text-gray-700">Sessões Pendentes</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="r in rows" :key="r.client_id + r.service_id" class="border-b last:border-b-0">
+                <td class="px-4 py-2">{{ getClientName(r.client_id) }}</td>
+                <td class="px-4 py-2">{{ getServiceName(r.service_id) }}</td>
+                <td class="px-4 py-2">{{ r.remaining }}</td>
+              </tr>
+              <tr v-if="rows.length === 0">
+                <td colspan="3" class="px-4 py-6 text-center text-gray-500">Nenhum registro</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  </div>
+</template>
+
+<script>
+import Sidebar from '../components/Sidebar.vue'
+import HeaderUser from '../components/HeaderUser.vue'
+import { supabase } from '../supabase'
+
+export default {
+  name: 'RelatorioEmAberto',
+  components: { Sidebar, HeaderUser },
+  data() {
+    return {
+      sidebarOpen: window.innerWidth >= 768,
+      userId: null,
+      clients: [],
+      services: [],
+      appointments: [],
+      clientId: '',
+      rows: []
+    }
+  },
+  methods: {
+    getClientName(id) {
+      const c = this.clients.find(cl => cl.id === id)
+      return c ? c.name : ''
+    },
+    getServiceName(id) {
+      const s = this.services.find(sv => sv.id === id)
+      return s ? s.name : ''
+    },
+    computeRows() {
+      const grouped = {}
+      this.appointments.forEach(a => {
+        const key = `${a.client_id}-${a.service_id}`
+        if (!grouped[key]) grouped[key] = 0
+        grouped[key] += 1
+      })
+      const rows = []
+      this.services.filter(s => s.is_package && s.session_count).forEach(svc => {
+        this.clients.forEach(cl => {
+          if (this.clientId && cl.id !== this.clientId) return
+          const key = `${cl.id}-${svc.id}`
+          const cnt = grouped[key] || 0
+          const rem = cnt % svc.session_count
+          if (rem > 0) {
+            rows.push({ client_id: cl.id, service_id: svc.id, remaining: svc.session_count - rem })
+          }
+        })
+      })
+      this.rows = rows
+    },
+    async fetchAppointments() {
+      let query = supabase
+        .from('appointments')
+        .select('client_id, service_id')
+        .eq('user_id', this.userId)
+      if (this.clientId) query = query.eq('client_id', this.clientId)
+      const { data } = await query
+      this.appointments = data || []
+    },
+    async generateReport() {
+      await this.fetchAppointments()
+      this.computeRows()
+    }
+  },
+  async mounted() {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      this.$router.push('/login')
+      return
+    }
+    this.userId = user.id
+
+    const { data: clientData } = await supabase
+      .from('clients')
+      .select()
+      .eq('user_id', this.userId)
+      .eq('active', true)
+    if (clientData) this.clients = clientData
+
+    const { data: serviceData } = await supabase
+      .from('services')
+      .select()
+      .eq('user_id', this.userId)
+      .eq('active', true)
+    if (serviceData) this.services = serviceData
+
+    await this.generateReport()
+  }
+}
+</script>
+


### PR DESCRIPTION
## Summary
- add RelatorioEmAberto.vue to show remaining package sessions
- register the new report route
- add "Em Aberto" link under Relatórios menu

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd17319008320a11d643d630f9f01