### PR TITLE
Remove description from confirmation email

### DIFF
--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -533,7 +533,6 @@ export default {
               `Seu agendamento para ${service?.name} foi confirmado para ${formatDateBR(this.form.date)} às ${this.form.time}.\n` +
               `${room ? `Sala: ${room.name}\n` : ''}` +
               `${room?.google_meet_link ? `Link: ${room.google_meet_link}\n` : ''}` +
-              `${this.form.description ? `Observações: ${this.form.description}\n` : ''}` +
               `\nE-mail enviado automaticamente.`
           }, false)
           this.closeModal()
@@ -657,8 +656,8 @@ export default {
           `Seu agendamento para ${service?.name} foi confirmado para ${formatDateBR(appt.date)} às ${addHoursToTime(appt.time)}.\n` +
           `${room ? `Sala: ${room.name}\n` : ''}` +
           `${room?.google_meet_link ? `Link: ${room.google_meet_link}\n` : ''}` +
-          `${appt.description ? `Observações: ${appt.description}\n` : ''}` +
           `\nE-mail enviado automaticamente.`
+
       })
     },
     async confirmPayment() {
@@ -687,7 +686,6 @@ export default {
           `Seu agendamento para ${service?.name} foi confirmado para ${formatDateBR(appt.date)} às ${addHoursToTime(appt.time)}.\n` +
           `${room ? `Sala: ${room.name}\n` : ''}` +
           `${room?.google_meet_link ? `Link: ${room.google_meet_link}\n` : ''}` +
-          `${appt.description ? `Observações: ${appt.description}\n` : ''}` +
           `\nE-mail enviado automaticamente.`
       }, false)
     },

--- a/src/views/Clientes.vue
+++ b/src/views/Clientes.vue
@@ -611,7 +611,6 @@ export default {
           `Seu agendamento para ${service?.name} foi confirmado para ${formatDateBR(appt.date)} às ${addHoursToTime(appt.time)}.\n` +
           `${room ? `Sala: ${room.name}\n` : ''}` +
           `${room?.google_meet_link ? `Link: ${room.google_meet_link}\n` : ''}` +
-          `${appt.description ? `Observações: ${appt.description}\n` : ''}` +
           `\nE-mail enviado automaticamente.`
       })
     },

--- a/src/views/NovoAgendamento.vue
+++ b/src/views/NovoAgendamento.vue
@@ -230,7 +230,6 @@ export default {
             `Seu agendamento para ${service?.name} foi confirmado para ${formatDateBR(this.form.date)} às ${this.form.time}.\n` +
             `${room ? `Sala: ${room.name}\n` : ''}` +
             `${room?.google_meet_link ? `Link: ${room.google_meet_link}\n` : ''}` +
-            `${this.form.description ? `Observações: ${this.form.description}\n` : ''}` +
             `\nE-mail enviado automaticamente.`
         }, false)
         this.$router.push('/agendamentos')


### PR DESCRIPTION
## Summary
- avoid sending appointment description in confirmation emails

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd91d19fc8320b10b8cb744454569