### PR TITLE
Fix pending session scheduling

### DIFF
--- a/src/views/NovoAgendamento.vue
+++ b/src/views/NovoAgendamento.vue
@@ -240,7 +240,14 @@ export default {
       if (error) {
         alert('Erro ao salvar agendamento: ' + error.message)
       } else {
-        if (serviceInfo && serviceInfo.is_package && serviceInfo.session_count && serviceInfo.session_count > 1 && existingCount % serviceInfo.session_count === 0) {
+        if (
+          serviceInfo &&
+          serviceInfo.is_package &&
+          serviceInfo.session_count &&
+          serviceInfo.session_count > 1 &&
+          !this.fieldsDisabled &&
+          existingCount % serviceInfo.session_count === 0
+        ) {
           const extra = []
           for (let i = 1; i < serviceInfo.session_count; i++) {
             extra.push({


### PR DESCRIPTION
## Summary
- ensure recurring sessions aren't automatically scheduled when handling a pending appointment

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe61196f48320924470960fe7d2fc