### PR TITLE
Fix pending session rescheduling

### DIFF
--- a/src/views/NovoAgendamento.vue
+++ b/src/views/NovoAgendamento.vue
@@ -137,8 +137,9 @@ export default {
         .eq('user_id', this.userId)
         .eq('client_id', clientId)
         .eq('status', 'canceled')
-        .order('date', { ascending: false })
-        .order('time', { ascending: false })
+        .order('created_at', { ascending: true })
+        .order('date', { ascending: true })
+        .order('time', { ascending: true })
         .limit(1)
         .maybeSingle()
 


### PR DESCRIPTION
## Summary
- use the oldest canceled appointment when searching for pending package sessions

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fea0ba2a883208079fb81681956f9