### PR TITLE
Fix pending session balance calculation

### DIFF
--- a/src/views/NovoAgendamento.vue
+++ b/src/views/NovoAgendamento.vue
@@ -173,8 +173,9 @@ export default {
       for (const svc of this.services.filter(s => s.is_package && s.session_count)) {
         const data = grouped[svc.id]
         if (!data) continue
-        const packages = Math.ceil(data.total / svc.session_count)
-        const remaining = packages * svc.session_count - data.active
+        const valid = data.active
+        const remainder = valid % svc.session_count
+        const remaining = remainder === 0 ? 0 : svc.session_count - remainder
         if (remaining > 0) {
           const confirmMsg = `O cliente possui sessões pendentes do serviço ${svc.name}. Deseja agendar para este serviço?`
           if (confirm(confirmMsg)) {

--- a/src/views/RelatorioEmAberto.vue
+++ b/src/views/RelatorioEmAberto.vue
@@ -96,8 +96,9 @@ export default {
             const key = `${cl.id}-${svc.id}`
             const data = stats[key]
             if (!data) return
-            const packages = Math.ceil(data.total / svc.session_count)
-            const remaining = packages * svc.session_count - data.active
+            const valid = data.active
+            const remainder = valid % svc.session_count
+            const remaining = remainder === 0 ? 0 : svc.session_count - remainder
             if (remaining > 0) {
               rows.push({ client_id: cl.id, service_id: svc.id, remaining })
             }


### PR DESCRIPTION
## Summary
- fix remaining sessions logic in pending report
- update new appointment page to use the same rule

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff44b2e948320ac0fdc671c0b19d0