### PR TITLE
Fix pending session calculation

### DIFF
--- a/src/views/NovoAgendamento.vue
+++ b/src/views/NovoAgendamento.vue
@@ -165,10 +165,12 @@ export default {
 
       const grouped = {}
       ;(appts || []).forEach(a => {
-        if (!grouped[a.service_id]) grouped[a.service_id] = { done: 0, pending: 0 }
+        if (!grouped[a.service_id]) grouped[a.service_id] = { done: 0, pending: 0, canceled: 0 }
         if (a.status === 'completed' || a.status === 'no_show') {
           grouped[a.service_id].done += 1
-        } else if (a.status !== 'canceled') {
+        } else if (a.status === 'canceled') {
+          grouped[a.service_id].canceled += 1
+        } else {
           grouped[a.service_id].pending += 1
         }
       })
@@ -176,8 +178,7 @@ export default {
       for (const svc of this.services.filter(s => s.is_package && s.session_count)) {
         const data = grouped[svc.id]
         if (!data) continue
-        const cycleRemaining = svc.session_count - (data.done % svc.session_count)
-        const remaining = Math.max(cycleRemaining - data.pending, 0)
+        const remaining = data.canceled
         if (remaining > 0) {
           const confirmMsg = `O cliente possui sessões pendentes do serviço ${svc.name}. Deseja agendar para este serviço?`
           if (confirm(confirmMsg)) {

--- a/src/views/RelatorioEmAberto.vue
+++ b/src/views/RelatorioEmAberto.vue
@@ -82,10 +82,12 @@ export default {
       const stats = {}
       this.appointments.forEach(a => {
         const key = `${a.client_id}-${a.service_id}`
-        if (!stats[key]) stats[key] = { done: 0, pending: 0 }
+        if (!stats[key]) stats[key] = { done: 0, pending: 0, canceled: 0 }
         if (a.status === 'completed' || a.status === 'no_show') {
           stats[key].done += 1
-        } else if (a.status !== 'canceled') {
+        } else if (a.status === 'canceled') {
+          stats[key].canceled += 1
+        } else {
           stats[key].pending += 1
         }
       })
@@ -99,8 +101,7 @@ export default {
             const key = `${cl.id}-${svc.id}`
             const data = stats[key]
             if (!data) return
-            const cycleRemaining = svc.session_count - (data.done % svc.session_count)
-            const remaining = Math.max(cycleRemaining - data.pending, 0)
+            const remaining = data.canceled
             if (remaining > 0) {
               rows.push({ client_id: cl.id, service_id: svc.id, remaining })
             }


### PR DESCRIPTION
## Summary
- fix calculation of open sessions when using service packages

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff7f2b4e88320857cfa5c2531f8f3