### PR TITLE
Fix pending session logic

### DIFF
--- a/src/views/RelatorioEmAberto.vue
+++ b/src/views/RelatorioEmAberto.vue
@@ -85,9 +85,9 @@ export default {
         if (!stats[key]) stats[key] = { done: 0, pending: 0, canceled: 0 }
         if (a.status === 'completed' || a.status === 'no_show') {
           stats[key].done += 1
-        } else if (a.status === 'canceled') {
+        } else if (a.status === 'canceled' && !a.rescheduled) {
           stats[key].canceled += 1
-        } else {
+        } else if (a.status !== 'canceled') {
           stats[key].pending += 1
         }
       })
@@ -112,7 +112,7 @@ export default {
     async fetchAppointments() {
       let query = supabase
         .from('appointments')
-        .select('client_id, service_id, status')
+        .select('client_id, service_id, status, rescheduled')
         .eq('user_id', this.userId)
       if (this.clientId) query = query.eq('client_id', this.clientId)
       const { data } = await query

--- a/supabase/schemas/035_add_rescheduled_to_appointments.sql
+++ b/supabase/schemas/035_add_rescheduled_to_appointments.sql
@@ -1,0 +1,1 @@
+alter table appointments add column if not exists rescheduled boolean default false;


### PR DESCRIPTION
## Summary
- track rescheduled appointments with a new DB column
- prefill reschedules in `NovoAgendamento` and mark originals as rescheduled
- ignore rescheduled cancellations in `RelatorioEmAberto`

## Testing
- `npm install` *(fails: registry access blocked)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff9690d288320badf3f781be39ddb