### PR TITLE
Fix recurring appointment replication logic

### DIFF
--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -512,7 +512,7 @@ export default {
           alert('Erro ao salvar agendamento: ' + error.message)
         } else {
           this.appointments.push(data)
-          if (serviceInfo && serviceInfo.is_package && serviceInfo.session_count && serviceInfo.session_count > 1 && existingCount % serviceInfo.session_count === 0) {
+          if (serviceInfo && serviceInfo.is_package && serviceInfo.session_count && serviceInfo.session_count > 1 && existingCount === 0) {
             const extra = []
             for (let i = 1; i < serviceInfo.session_count; i++) {
               extra.push({

--- a/src/views/NovoAgendamento.vue
+++ b/src/views/NovoAgendamento.vue
@@ -265,7 +265,7 @@ export default {
           serviceInfo.session_count &&
           serviceInfo.session_count > 1 &&
           !this.fieldsDisabled &&
-          existingCount % serviceInfo.session_count === 0
+          existingCount === 0
         ) {
           const extra = []
           for (let i = 1; i < serviceInfo.session_count; i++) {


### PR DESCRIPTION
## Summary
- replicate package appointments only when starting a new cycle

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ffd8a06a4832092408721b221c4d3