### PR TITLE
Fix recurring appointment creation

### DIFF
--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -512,7 +512,13 @@ export default {
           alert('Erro ao salvar agendamento: ' + error.message)
         } else {
           this.appointments.push(data)
-          if (serviceInfo && serviceInfo.is_package && serviceInfo.session_count && serviceInfo.session_count > 1 && existingCount === 0) {
+          if (
+            serviceInfo &&
+            serviceInfo.is_package &&
+            serviceInfo.session_count &&
+            serviceInfo.session_count > 1 &&
+            existingCount % serviceInfo.session_count === 0
+          ) {
             const extra = []
             for (let i = 1; i < serviceInfo.session_count; i++) {
               extra.push({

--- a/src/views/NovoAgendamento.vue
+++ b/src/views/NovoAgendamento.vue
@@ -265,7 +265,7 @@ export default {
           serviceInfo.session_count &&
           serviceInfo.session_count > 1 &&
           !this.fieldsDisabled &&
-          existingCount === 0
+          existingCount % serviceInfo.session_count === 0
         ) {
           const extra = []
           for (let i = 1; i < serviceInfo.session_count; i++) {


### PR DESCRIPTION
## Summary
- correct recurrence logic in `Agendamentos.vue`
- replicate package sessions when starting a new package in `NovoAgendamento.vue`

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686022d8df9083209e8ad83121dcac61