### PR TITLE
Update recurring appointment conditions

### DIFF
--- a/src/views/NovoAgendamento.vue
+++ b/src/views/NovoAgendamento.vue
@@ -264,8 +264,9 @@ export default {
           serviceInfo.is_package &&
           serviceInfo.session_count &&
           serviceInfo.session_count > 1 &&
-          !this.fieldsDisabled &&
-          existingCount % serviceInfo.session_count === 0
+          (!this.reschedulingId ||
+            (!this.fieldsDisabled &&
+              existingCount % serviceInfo.session_count === 0))
         ) {
           const extra = []
           for (let i = 1; i < serviceInfo.session_count; i++) {


### PR DESCRIPTION
## Summary
- adjust logic so packages generate additional sessions by default
- check reschedule-related conditions only when rescheduling

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686025e6c1f883209b29768711cb5a75