### PR TITLE
Mark deleted appointments

### DIFF
--- a/src/views/Comprovantes.vue
+++ b/src/views/Comprovantes.vue
@@ -132,6 +132,8 @@ export default {
         .eq('client_id', this.generateForm.clientId)
         .gte('date', this.generateForm.startDate)
         .lte('date', this.generateForm.endDate)
+        .neq('status', 'canceled')
+        .neq('status', 'deleted')
         .order('date', { ascending: true })
         .order('time', { ascending: true })
 

--- a/src/views/NovoAgendamento.vue
+++ b/src/views/NovoAgendamento.vue
@@ -172,9 +172,9 @@ export default {
         if (!grouped[a.service_id]) grouped[a.service_id] = { done: 0, pending: 0, canceled: 0 }
         if (a.status === 'completed' || a.status === 'no_show') {
           grouped[a.service_id].done += 1
-        } else if (a.status === 'canceled' && !a.rescheduled) {
+        } else if ((a.status === 'canceled' || a.status === 'deleted') && !a.rescheduled) {
           grouped[a.service_id].canceled += 1
-        } else if (a.status !== 'canceled') {
+        } else if (a.status !== 'canceled' && a.status !== 'deleted') {
           grouped[a.service_id].pending += 1
         }
       })

--- a/src/views/RelatorioAgendamentos.vue
+++ b/src/views/RelatorioAgendamentos.vue
@@ -125,6 +125,8 @@ export default {
         .eq('user_id', this.userId)
         .gte('date', this.filterStart)
         .lte('date', this.filterEnd)
+        .neq('status', 'canceled')
+        .neq('status', 'deleted')
 
       if (this.clientId) {
         query = query.eq('client_id', this.clientId)

--- a/src/views/RelatorioEmAberto.vue
+++ b/src/views/RelatorioEmAberto.vue
@@ -85,9 +85,9 @@ export default {
         if (!stats[key]) stats[key] = { done: 0, pending: 0, canceled: 0 }
         if (a.status === 'completed' || a.status === 'no_show') {
           stats[key].done += 1
-        } else if (a.status === 'canceled' && !a.rescheduled) {
+        } else if ((a.status === 'canceled' || a.status === 'deleted') && !a.rescheduled) {
           stats[key].canceled += 1
-        } else if (a.status !== 'canceled') {
+        } else if (a.status !== 'canceled' && a.status !== 'deleted') {
           stats[key].pending += 1
         }
       })
@@ -114,6 +114,7 @@ export default {
         .from('appointments')
         .select('client_id, service_id, status, rescheduled')
         .eq('user_id', this.userId)
+        .neq('status', 'deleted')
       if (this.clientId) query = query.eq('client_id', this.clientId)
       const { data } = await query
       this.appointments = data || []


### PR DESCRIPTION
## Summary
- update delete logic for appointments to keep a deleted status instead of removing records
- filter canceled and deleted appointments from lists and reports
- adjust computations that group appointment statuses
- update dashboard actions for canceling and deleting appointments

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68602eddd7648320808cb2d05a1d6aff