### PR TITLE
Fix tests for router-link stubs

### DIFF
--- a/src/components/__tests__/AppointmentDetails.test.ts
+++ b/src/components/__tests__/AppointmentDetails.test.ts
@@ -22,7 +22,11 @@ describe('AppointmentDetails', () => {
         getRoomName: () => 'Sala 1',
         getRoomLink: () => 'https://meet.google.com/test'
       },
-      global: { stubs: ['router-link'] }
+      global: {
+        stubs: {
+          'router-link': { template: '<a><slot /></a>' }
+        }
+      }
     })
     expect(getByText('Detalhes do Agendamento')).toBeTruthy()
     expect(getByText('Cliente: Cliente 1')).toBeTruthy()

--- a/src/components/__tests__/HeroBanner.test.ts
+++ b/src/components/__tests__/HeroBanner.test.ts
@@ -13,7 +13,13 @@ vi.mock('../../supabase', () => ({
 
 describe('HeroBanner', () => {
   it('renders call to action', () => {
-    const { getByText } = render(HeroBanner, { global: { stubs: ['router-link'] } })
+    const { getByText } = render(HeroBanner, {
+      global: {
+        stubs: {
+          'router-link': { template: '<a><slot /></a>' }
+        }
+      }
+    })
     expect(getByText(/agenda digital simples/i)).toBeTruthy()
     expect(getByText('Criar conta')).toBeTruthy()
   })

--- a/src/components/__tests__/Navbar.test.ts
+++ b/src/components/__tests__/Navbar.test.ts
@@ -13,7 +13,13 @@ vi.mock('../../supabase', () => ({
 
 describe('Navbar', () => {
   it('renders brand name', () => {
-    const { getByText } = render(Navbar, { global: { stubs: ['router-link'] } })
+    const { getByText } = render(Navbar, {
+      global: {
+        stubs: {
+          'router-link': { template: '<a><slot /></a>' }
+        }
+      }
+    })
     expect(getByText('Agenda Zen')).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
- stub router-link with template slot in component tests so slot text is rendered

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `npx vitest run` *(fails: 403 Forbidden because internet access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68606759902c8320b14faaae44dfc940