### PR TITLE
Fix AppointmentDetails test

### DIFF
--- a/src/components/__tests__/AppointmentDetails.test.ts
+++ b/src/components/__tests__/AppointmentDetails.test.ts
@@ -29,6 +29,6 @@ describe('AppointmentDetails', () => {
       }
     })
     expect(getByText('Detalhes do Agendamento')).toBeTruthy()
-    expect(getByText('Cliente: Cliente 1')).toBeTruthy()
+    expect(getByText(/Cliente:\s*Cliente 1/)).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
- tweak AppointmentDetails test to handle text split across elements

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606868d3108320aaed36b00d422cdc