### PR TITLE
Fix appointment details test matcher

### DIFF
--- a/src/components/__tests__/AppointmentDetails.test.ts
+++ b/src/components/__tests__/AppointmentDetails.test.ts
@@ -29,6 +29,10 @@ describe('AppointmentDetails', () => {
       }
     })
     expect(getByText('Detalhes do Agendamento')).toBeTruthy()
-    expect(getByText(/Cliente:\s*Cliente 1/)).toBeTruthy()
+    expect(
+      getByText((content, element) =>
+        /Cliente:\s*Cliente 1/.test(element?.textContent || '')
+      )
+    ).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
- adjust the AppointmentDetails test matcher to search using textContent so the text split across elements is matched

## Testing
- `npm test -- -t AppointmentDetails --run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686069723e788320926b681f6e6002a6