### PR TITLE
Fix AppointmentDetails test query

### DIFF
--- a/src/components/__tests__/AppointmentDetails.test.ts
+++ b/src/components/__tests__/AppointmentDetails.test.ts
@@ -29,10 +29,7 @@ describe('AppointmentDetails', () => {
       }
     })
     expect(getByText('Detalhes do Agendamento')).toBeTruthy()
-    expect(
-      getByText((content, element) =>
-        /Cliente:\s*Cliente 1/.test(element?.textContent || '')
-      )
-    ).toBeTruthy()
+    expect(getByText('Cliente:')).toBeTruthy()
+    expect(getByText('Cliente 1')).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
- update `AppointmentDetails` test to query text without regex

## Testing
- `npm test -- -t AppointmentDetails.test.ts --run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606a6828008320ba0d0cfa724f9e8a