### PR TITLE
Improve agenda UI with Tailwind

### DIFF
--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="bg-white rounded-lg shadow overflow-hidden">
-    <div class="flex justify-between items-center px-4 py-2 border-b bg-gray-50">
-      <button @click="prevMonth" class="p-1 rounded hover:bg-gray-200">
+    <div class="flex justify-between items-center px-4 py-2 border-b bg-blue-600 text-white">
+      <button @click="prevMonth" class="p-1 rounded hover:bg-blue-500">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
         </svg>
       </button>
       <div class="font-semibold">{{ monthNames[currentMonth] }} {{ currentYear }}</div>
-      <button @click="nextMonth" class="p-1 rounded hover:bg-gray-200">
+      <button @click="nextMonth" class="p-1 rounded hover:bg-blue-500">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
         </svg>
@@ -15,7 +15,7 @@
     </div>
     <div class="grid grid-cols-7 gap-px text-sm bg-gray-100">
       <div
-        class="font-semibold text-center bg-gray-50 p-1"
+        class="font-semibold text-center bg-blue-50 text-blue-700 p-1"
         v-for="day in daysOfWeek"
         :key="day"
       >
@@ -25,7 +25,7 @@
       <div
         v-for="day in daysInMonth"
         :key="day"
-        class="border border-gray-200 h-24 p-1 overflow-auto bg-white"
+        class="border border-gray-200 h-24 p-1 overflow-auto bg-white hover:bg-blue-50"
         :class="{ 'bg-blue-50 border-l-4 border-blue-500': isToday(day) }"
       >
         <div class="text-center font-medium">{{ day }}</div>
@@ -33,7 +33,7 @@
           <li
             v-for="appt in getAppointmentsForDay(day)"
             :key="appt.id"
-            class="text-xs truncate cursor-pointer"
+            class="text-xs truncate cursor-pointer hover:underline"
             :class="getStatusClass(appt)"
             @click="$emit('select', appt)"
           >

--- a/src/components/WeekView.vue
+++ b/src/components/WeekView.vue
@@ -1,14 +1,14 @@
 
 <template>
   <div class="bg-white rounded-lg shadow overflow-hidden">
-    <div class="flex justify-between items-center px-4 py-2 border-b bg-gray-50">
-      <button @click="prevWeek" class="p-1 rounded hover:bg-gray-200">
+    <div class="flex justify-between items-center px-4 py-2 border-b bg-blue-600 text-white">
+      <button @click="prevWeek" class="p-1 rounded hover:bg-blue-500">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
         </svg>
       </button>
       <div class="font-semibold">{{ formatDate(weekStart) }} - {{ formatDate(weekEnd) }}</div>
-      <button @click="nextWeek" class="p-1 rounded hover:bg-gray-200">
+      <button @click="nextWeek" class="p-1 rounded hover:bg-blue-500">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
         </svg>
@@ -42,7 +42,7 @@
           <div
             v-for="day in 7"
             :key="'cell-' + day + '-' + hour"
-            class="relative bg-white border"
+            class="relative bg-white border hover:bg-blue-50"
           ></div>
         </template>
 
@@ -50,7 +50,7 @@
         <div
           v-for="event in events"
           :key="event.id"
-          class="absolute text-white rounded px-2 py-1 event cursor-pointer"
+          class="absolute text-white rounded px-2 py-1 event cursor-pointer hover:opacity-90"
           :class="getStatusClass(event.appointment)"
           :style="getEventStyle(event)"
           :title="getStatusTitle(event.appointment)"

--- a/src/views/Agendamentos.vue
+++ b/src/views/Agendamentos.vue
@@ -189,26 +189,26 @@
           <div class="bg-white p-4 rounded-lg shadow">
             <div class="overflow-x-auto">
               <table class="min-w-full text-left">
-              <thead class="bg-gray-50">
+              <thead class="bg-blue-600 text-white">
                 <tr>
-                  <th @click="sortBy('datetime')" class="px-4 py-2 font-medium text-gray-700 cursor-pointer">
+                  <th @click="sortBy('datetime')" class="px-4 py-2 font-medium text-white cursor-pointer">
                     Data/Hora
                     <span v-if="sortColumn === 'datetime'">{{ sortAsc ? '▲' : '▼' }}</span>
                   </th>
-                  <th @click="sortBy('client')" class="px-4 py-2 font-medium text-gray-700 cursor-pointer">
+                  <th @click="sortBy('client')" class="px-4 py-2 font-medium text-white cursor-pointer">
                     Cliente
                     <span v-if="sortColumn === 'client'">{{ sortAsc ? '▲' : '▼' }}</span>
                   </th>
-                 <th @click="sortBy('service')" class="px-4 py-2 font-medium text-gray-700 cursor-pointer">
+                 <th @click="sortBy('service')" class="px-4 py-2 font-medium text-white cursor-pointer">
                     Serviço
                     <span v-if="sortColumn === 'service'">{{ sortAsc ? '▲' : '▼' }}</span>
                   </th>
-                  <th class="px-4 py-2 font-medium text-gray-700">Sala</th>
-                  <th @click="sortBy('duration')" class="px-4 py-2 font-medium text-gray-700 cursor-pointer">
+                  <th class="px-4 py-2 font-medium text-white">Sala</th>
+                  <th @click="sortBy('duration')" class="px-4 py-2 font-medium text-white cursor-pointer">
                     Duração
                     <span v-if="sortColumn === 'duration'">{{ sortAsc ? '▲' : '▼' }}</span>
                   </th>
-                  <th @click="sortBy('description')" class="px-4 py-2 font-medium text-gray-700 cursor-pointer">
+                  <th @click="sortBy('description')" class="px-4 py-2 font-medium text-white cursor-pointer">
                     Descrição
                     <span v-if="sortColumn === 'description'">{{ sortAsc ? '▲' : '▼' }}</span>
                   </th>
@@ -219,7 +219,7 @@
                 <tr
                   v-for="appointment in processedAppointments"
                   :key="appointment.id"
-                  :class="['border-b last:border-b-0', getRowClass(appointment)]"
+                  :class="['border-b last:border-b-0 even:bg-gray-50 hover:bg-blue-50', getRowClass(appointment)]"
                 >
                   <td class="px-4 py-2">{{ formatDateBR(appointment.date) }} {{ addHoursToTime(appointment.time) }}</td>
                   <td class="px-4 py-2">{{ getClientName(appointment.client_id) }}</td>


### PR DESCRIPTION
## Summary
- style calendar header and days with blue theme
- enhance week view navigation bar and event hover
- polish appointments table with blue header and row highlights

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860748310388320b623e799dd6bb9f5