### PR TITLE
Implement company support

### DIFF
--- a/src/views/Configuracao.vue
+++ b/src/views/Configuracao.vue
@@ -46,6 +46,10 @@
             </p>
           </div>
           <div>
+            <label class="block text-sm font-medium text-gray-700">Nome da Empresa</label>
+            <input type="text" v-model="form.companyName" class="w-full mt-1 px-4 py-2 border rounded-md">
+          </div>
+          <div>
             <label class="block text-sm font-medium text-gray-700">Descrição do Estabelecimento</label>
             <textarea v-model="form.description" class="w-full mt-1 px-4 py-2 border rounded-md"></textarea>
           </div>
@@ -170,11 +174,13 @@ import { isValidEmail } from '../utils/format'
     data() {
       return {
         userId: null,
+        companyId: null,
         sidebarOpen: window.innerWidth >= 768,
         slug: '',
         activeTab: 'perfil',
         form: {
           businessName: '',
+          companyName: '',
           description: '',
           areaAtuacao: '',
           phone: '',
@@ -246,7 +252,14 @@ import { isValidEmail } from '../utils/format'
         const { error } = await supabase
           .from('profiles')
           .upsert(updates, { onConflict: ['id'] })
-  
+
+        if (!error && this.companyId) {
+          await supabase
+            .from('companies')
+            .update({ name: this.form.companyName })
+            .eq('id', this.companyId)
+        }
+
         if (error) {
           alert('Erro ao salvar dados: ' + error.message)
         } else {
@@ -314,8 +327,10 @@ import { isValidEmail } from '../utils/format'
         .single()
   
       if (data) {
+        this.companyId = data.company_id || null
         this.form = {
           businessName: data.business_name || '',
+          companyName: '',
           description: data.description || '',
           areaAtuacao: data.area_atuacao || '',
           phone: data.phone || '',
@@ -328,6 +343,14 @@ import { isValidEmail } from '../utils/format'
           x: data.x || '',
           imageUrl: data.image_url || '',
           pixKey: data.pix_key || ''
+        }
+        if (this.companyId) {
+          const { data: company } = await supabase
+            .from('companies')
+            .select('name')
+            .eq('id', this.companyId)
+            .single()
+          if (company) this.form.companyName = company.name
         }
         this.agenda = {
           cancelLimitHours: data.cancel_limit_hours || 0,

--- a/src/views/Signup.vue
+++ b/src/views/Signup.vue
@@ -19,6 +19,10 @@
             <label class="block text-sm font-medium text-gray-700 mb-1" for="password">Senha</label>
             <input v-model="password" type="password" id="password" placeholder="********" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
           </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1" for="company">Empresa</label>
+            <input v-model="company" type="text" id="company" placeholder="Nome da empresa" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          </div>
         <button type="submit" class="btn w-full">Cadastrar</button>
       </form>
       <p class="mt-6 text-center text-sm text-gray-500">
@@ -42,7 +46,8 @@ export default {
     return {
       name: '',
       email: '',
-      password: ''
+      password: '',
+      company: ''
     }
   },
   methods: {
@@ -51,10 +56,26 @@ export default {
         alert('Informe o nome')
         return
       }
+      if (!this.company) {
+        alert('Informe a empresa')
+        return
+      }
       if (this.email && !isValidEmail(this.email)) {
         alert('E-mail inválido')
         return
       }
+
+      const { data: companyData, error: companyError } = await supabase
+        .from('companies')
+        .insert({ name: this.company })
+        .select('id')
+        .single()
+
+      if (companyError) {
+        alert('Erro ao criar empresa: ' + companyError.message)
+        return
+      }
+
       const { data, error } = await supabase.auth.signUp({
         email: this.email,
         password: this.password,
@@ -66,6 +87,12 @@ export default {
       if (error) {
         alert('Erro ao cadastrar: ' + error.message)
       } else {
+        if (data?.user && companyData) {
+          await supabase.from('profiles').insert({
+            id: data.user.id,
+            company_id: companyData.id
+          })
+        }
         alert('Cadastro realizado! Verifique seu e-mail para ativar a conta.')
       }
     }

--- a/src/views/Usuarios.vue
+++ b/src/views/Usuarios.vue
@@ -132,7 +132,7 @@ export default {
       if (currentUser) {
         const { data } = await supabase
           .from('profiles')
-          .select('*')
+          .select('company_id')
           .eq('id', currentUser.id)
           .single()
         profileData = data
@@ -153,17 +153,7 @@ export default {
         if (signUpData?.user && profileData) {
           await supabase.from('profiles').insert({
             id: signUpData.user.id,
-            business_name: profileData.business_name,
-            description: profileData.description,
-            phone: profileData.phone,
-            whatsapp: profileData.whatsapp,
-            email: profileData.email,
-            address: profileData.address,
-            instagram: profileData.instagram,
-            facebook: profileData.facebook,
-            youtube: profileData.youtube,
-            x: profileData.x,
-            slug: profileData.slug
+            company_id: profileData.company_id
           })
         }
         this.successMessage = 'Usuário cadastrado! Verifique o e-mail para ativar a conta.'
@@ -227,7 +217,7 @@ export default {
     async fetchUsers() {
       const { data: profile } = await supabase
         .from('profiles')
-        .select('slug')
+        .select('company_id')
         .eq('id', this.userId)
         .single()
 
@@ -235,7 +225,7 @@ export default {
         const { data } = await supabase
           .from('profiles')
           .select('id, email')
-          .eq('slug', profile.slug)
+          .eq('company_id', profile.company_id)
 
         this.users = data || []
       }

--- a/src/views/__tests__/Configuracao.test.ts
+++ b/src/views/__tests__/Configuracao.test.ts
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/vue'
+import { describe, it, expect, vi } from 'vitest'
+import Configuracao from '../Configuracao.vue'
+
+vi.mock('../../supabase', () => ({
+  supabase: {
+    from: () => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: {}, error: null }),
+      update: vi.fn(),
+      upsert: vi.fn()
+    }),
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: '1' } } }), signOut: vi.fn() }
+  }
+}))
+
+describe('Configuracao view', () => {
+  it('renders company name field', async () => {
+    const { getByLabelText } = render(Configuracao, { global: { stubs: ['router-link'] } })
+    expect(getByLabelText('Nome da Empresa')).toBeTruthy()
+  })
+})

--- a/src/views/__tests__/Signup.test.ts
+++ b/src/views/__tests__/Signup.test.ts
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/vue'
+import { describe, it, expect, vi } from 'vitest'
+import Signup from '../Signup.vue'
+
+vi.mock('../../supabase', () => ({
+  supabase: {
+    from: () => ({ insert: vi.fn().mockReturnValue({ select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { id: '1' }, error: null }) }) }) }),
+    auth: { signUp: vi.fn().mockResolvedValue({ data: { user: { id: '1' } }, error: null }) }
+  }
+}))
+
+describe('Signup view', () => {
+  it('renders company field', () => {
+    const { getByLabelText } = render(Signup, { global: { stubs: ['router-link'] } })
+    expect(getByLabelText('Empresa')).toBeTruthy()
+  })
+})

--- a/supabase/schemas/036_create_companies.sql
+++ b/supabase/schemas/036_create_companies.sql
@@ -1,0 +1,21 @@
+create table if not exists companies (
+  id uuid primary key default uuid_generate_v4(),
+  name text not null,
+  phone text,
+  email text,
+  address text,
+  created_at timestamp with time zone default now()
+);
+
+alter table companies enable row level security;
+
+create policy "Authenticated can insert companies" on companies
+  for insert with check (auth.uid() is not null);
+
+create policy "Company members can manage company" on companies
+  for all using (
+    exists (
+      select 1 from profiles p
+      where p.id = auth.uid() and p.company_id = id
+    )
+  );

--- a/supabase/schemas/037_add_company_id_to_profiles.sql
+++ b/supabase/schemas/037_add_company_id_to_profiles.sql
@@ -1,0 +1,1 @@
+alter table profiles add column if not exists company_id uuid references companies(id);


### PR DESCRIPTION
## Summary
- add company input on signup
- create companies table
- associate new users with a company
- fetch company users on user admin page
- add company field on profile page
- test signup and profile views for company fields

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68607f856efc83208240dc68fac3a1c0