### PR TITLE
Fix user fetch when company_id is null

### DIFF
--- a/src/views/Usuarios.vue
+++ b/src/views/Usuarios.vue
@@ -222,11 +222,17 @@ export default {
         .single()
 
       if (profile) {
-        const { data } = await supabase
+        let query = supabase
           .from('profiles')
           .select('id, email')
-          .eq('company_id', profile.company_id)
 
+        if (profile.company_id === null) {
+          query = query.is('company_id', null)
+        } else {
+          query = query.eq('company_id', profile.company_id)
+        }
+
+        const { data } = await query
         this.users = data || []
       }
     }


### PR DESCRIPTION
## Summary
- handle null company_id when loading user list

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686126c588948320a67cfc15c2303270