### PR TITLE
Fix company creation flow

### DIFF
--- a/src/views/Empresa.vue
+++ b/src/views/Empresa.vue
@@ -93,21 +93,21 @@ export default {
         return
       }
       if (!this.companyId) {
-        const { data: company, error } = await supabase
+        const newId = crypto.randomUUID()
+        const { error } = await supabase
           .from('companies')
           .insert({
+            id: newId,
             name: this.form.name,
             phone: this.form.phone,
             email: this.form.email,
             address: this.form.address
           })
-          .select('id')
-          .single()
         if (error) {
           alert('Erro ao salvar dados: ' + error.message)
           return
         }
-        this.companyId = company.id
+        this.companyId = newId
         const { data: { user } } = await supabase.auth.getUser()
         if (user) {
           await supabase

--- a/src/views/Signup.vue
+++ b/src/views/Signup.vue
@@ -76,24 +76,23 @@ export default {
       if (error) {
         alert('Erro ao cadastrar: ' + error.message)
       } else {
-        if (data?.session) {
-          const { data: companyData, error: companyError } = await supabase
-            .from('companies')
-            .insert({ name: this.company })
-            .select('id')
-            .single()
+          if (data?.session) {
+            const companyId = crypto.randomUUID()
+            const { error: companyError } = await supabase
+              .from('companies')
+              .insert({ id: companyId, name: this.company })
 
-          if (companyError) {
-            alert('Erro ao criar empresa: ' + companyError.message)
-            return
-          }
+            if (companyError) {
+              alert('Erro ao criar empresa: ' + companyError.message)
+              return
+            }
 
-          await supabase.from('profiles').insert({
-            id: data.user.id,
-            company_id: companyData.id
-          })
-          alert('Cadastro realizado!')
-        } else {
+            await supabase.from('profiles').insert({
+              id: data.user.id,
+              company_id: companyId
+            })
+            alert('Cadastro realizado!')
+          } else {
           alert('Cadastro realizado! Verifique seu e-mail para ativar a conta e depois associe a empresa.')
         }
       }


### PR DESCRIPTION
## Summary
- fix company insertion logic by generating UUID client-side during signup
- avoid selecting new company record when creating a company

## Testing
- `npm install` *(fails: E403 Forbidden)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861344e6ec48320ab67e7eeb0ed160d