### PR TITLE
Load company by route id

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -43,7 +43,7 @@ const routes = [
   { path: '/login', name: 'Login', component: Login },
   { path: '/onboarding', name: 'Onboarding', component: Onboarding },
   { path: '/dashboard', name: 'Dashboard', component: Dashboard },
-  { path: '/empresa', name: 'Empresa', component: Empresa },
+  { path: '/empresa/:id?', name: 'Empresa', component: Empresa },
   { path: '/configuracao', name: 'Configuracao', component: Configuracao },
   { path: '/clientes', name: 'Clientes', component: Clientes },
   { path: '/servicos', name: 'Servicos', component: Servicos },

--- a/src/views/Empresa.vue
+++ b/src/views/Empresa.vue
@@ -60,37 +60,19 @@ export default {
   methods: {
     phoneMask,
     async fetchCompany() {
-      const {
-        data: { user },
-        error: userError
-      } = await supabase.auth.getUser()
-      console.log('fetchCompany - user', user, userError)
-      if (!user) {
-        this.$router.push('/login')
-        return
-      }
-      const { data: profile, error: profileError } = await supabase
-        .from('profiles')
-        .select('company_id')
-        .eq('id', user.id)
+      if (!this.companyId) return
+      const { data: company, error: companyError } = await supabase
+        .from('companies')
+        .select('name, phone, email, address')
+        .eq('id', this.companyId)
         .single()
-      console.log('fetchCompany - profile', profile, profileError)
-      if (profile && profile.company_id) {
-        this.companyId = profile.company_id
-        console.log('fetchCompany - companyId', this.companyId)
-        const { data: company, error: companyError } = await supabase
-          .from('companies')
-          .select('name, phone, email, address')
-          .eq('id', this.companyId)
-          .single()
-        console.log('fetchCompany - company', company, companyError)
-        if (company) {
-          this.form = {
-            name: company.name || '',
-            phone: company.phone || '',
-            email: company.email || '',
-            address: company.address || ''
-          }
+      console.log('fetchCompany - company', company, companyError)
+      if (company) {
+        this.form = {
+          name: company.name || '',
+          phone: company.phone || '',
+          email: company.email || '',
+          address: company.address || ''
         }
       }
     },
@@ -142,6 +124,7 @@ export default {
     }
   },
   async mounted() {
+    this.companyId = this.$route.params.id || null
     await this.fetchCompany()
   }
 }


### PR DESCRIPTION
## Summary
- allow company route to accept an optional id parameter
- fetch company using the provided id rather than looking it up by user profile

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686156566df083208c68549dfb06d6f2