### PR TITLE
Fix unhandled route error in Empresa test

### DIFF
--- a/src/views/__tests__/Empresa.test.ts
+++ b/src/views/__tests__/Empresa.test.ts
@@ -16,7 +16,12 @@ vi.mock('../../supabase', () => ({
 
 describe('Empresa view', () => {
   it('renders company name field', () => {
-    const { getByLabelText } = render(Empresa, { global: { stubs: ['router-link'] } })
+    const { getByLabelText } = render(Empresa, {
+      global: {
+        stubs: ['router-link'],
+        mocks: { $route: { params: {} } }
+      }
+    })
     expect(getByLabelText('Nome da Empresa')).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
- mock `$route` in Empresa view test to avoid accessing undefined params

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615aebef1883208537ef0c82fa2d5b