### PR TITLE
Handle company users onboarding

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -78,15 +78,23 @@ const router = createRouter({
 
 router.beforeEach(async (to, from, next) => {
   const { data: { user } } = await supabase.auth.getUser()
-  if (user && to.path !== '/onboarding') {
+  if (user) {
     const { data } = await supabase
       .from('profiles')
-      .select('onboarding_complete')
+      .select('onboarding_complete, company_id')
       .eq('id', user.id)
       .single()
+
     if (data && !data.onboarding_complete) {
-      next('/onboarding')
-      return
+      if (data.company_id) {
+        if (!to.path.startsWith('/empresa')) {
+          next('/empresa')
+          return
+        }
+      } else if (to.path !== '/onboarding') {
+        next('/onboarding')
+        return
+      }
     }
   }
   next()

--- a/src/views/Usuarios.vue
+++ b/src/views/Usuarios.vue
@@ -154,10 +154,14 @@ export default {
         this.errorMessage = 'Erro ao cadastrar usuário: ' + error.message
       } else {
         if (signUpData?.user && profileData) {
-          await supabase.from('profiles').insert({
-            id: signUpData.user.id,
-            company_id: profileData.company_id
-          })
+          await supabase.from('profiles').upsert(
+            {
+              id: signUpData.user.id,
+              company_id: profileData.company_id,
+              email: signUpData.user.email
+            },
+            { onConflict: ['id'] }
+          )
         }
         this.successMessage = 'Usuário cadastrado! Verifique o e-mail para ativar a conta.'
         this.form = { email: '', password: '' }


### PR DESCRIPTION
## Summary
- ensure new company users appear in list by saving email in profile
- skip onboarding redirect when user already belongs to a company and send them to the company page

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861639b503c8320a49407223a7165e2