### PR TITLE
Implement admin permissions module

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -143,6 +143,12 @@
               </svg>
               <span>Usuários</span>
             </router-link>
+            <router-link to="/permissoes" class="flex items-center text-gray-700 hover:text-primary">
+              <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+              </svg>
+              <span>Permissões</span>
+            </router-link>
             <router-link to="/minha-assinatura" class="flex items-center text-gray-700 hover:text-primary">
               <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <rect x="3" y="4" width="18" height="16" rx="2" ry="2" stroke-width="2" />

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -32,6 +32,7 @@ import PagamentoAgendamento from '../views/PagamentoAgendamento.vue'
 import Confirmacao from '../views/Confirmacao.vue'
 import LinkExpirado from '../views/LinkExpirado.vue'
 import Despesas from '../views/Despesas.vue'
+import Permissoes from '../views/Permissoes.vue'
 import { supabase } from '../supabase'
 
 
@@ -54,6 +55,7 @@ const routes = [
   { path: '/despesas', name: 'Despesas', component: Despesas },
   { path: '/templates', name: 'Templates', component: Templates },
   { path: '/usuarios', name: 'Usuarios', component: Usuarios },
+  { path: '/permissoes', name: 'Permissoes', component: Permissoes },
   { path: '/minha-assinatura', name: 'MinhaAssinatura', component: MinhaAssinatura },
   { path: '/assinatura-plus', name: 'PagamentoPlus', component: PagamentoPlus },
   { path: '/relatorio-em-aberto', name: 'RelatorioEmAberto', component: RelatorioEmAberto },

--- a/src/views/Permissoes.vue
+++ b/src/views/Permissoes.vue
@@ -1,0 +1,129 @@
+<template>
+  <div class="min-h-screen flex bg-gray-100 relative">
+    <Sidebar :is-open="sidebarOpen" @close="sidebarOpen = false" />
+    <main class="flex-1 p-8 space-y-6">
+      <div v-if="!sidebarOpen" class="flex items-center mb-4">
+        <button @click="sidebarOpen = true" class="text-gray-600 focus:outline-none">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+      <HeaderUser title="Permissões" />
+      <section class="bg-white p-4 rounded-lg shadow">
+        <h3 class="text-lg font-medium mb-4">Cadastrar permissão</h3>
+        <form @submit.prevent="addPermission" class="space-y-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Usuário</label>
+            <select v-model="form.profileId" class="w-full mt-1 px-4 py-2 border rounded-md">
+              <option value="" disabled>Selecione</option>
+              <option v-for="u in users" :key="u.id" :value="u.id">{{ u.email }}</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Tela</label>
+            <input type="text" v-model="form.screen" class="w-full mt-1 px-4 py-2 border rounded-md" />
+          </div>
+          <div class="flex items-center">
+            <input type="checkbox" v-model="form.canView" id="canView" class="mr-2" />
+            <label for="canView">Pode visualizar</label>
+          </div>
+          <div class="flex justify-end">
+            <button type="submit" class="btn">Salvar</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="bg-white p-4 rounded-lg shadow">
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-lg font-medium">Permissões cadastradas</h3>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="min-w-full text-left">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="px-4 py-2 font-medium text-gray-700">Usuário</th>
+                <th class="px-4 py-2 font-medium text-gray-700">Tela</th>
+                <th class="px-4 py-2 font-medium text-gray-700">Pode ver</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="p in permissions" :key="p.id" class="border-b last:border-b-0">
+                <td class="px-4 py-2">{{ getUserEmail(p.profile_id) }}</td>
+                <td class="px-4 py-2">{{ p.screen }}</td>
+                <td class="px-4 py-2">{{ p.can_view ? 'Sim' : 'Não' }}</td>
+              </tr>
+              <tr v-if="permissions.length === 0">
+                <td colspan="3" class="px-4 py-6 text-center text-gray-500">Nenhuma permissão</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  </div>
+</template>
+
+<script>
+import Sidebar from '../components/Sidebar.vue'
+import HeaderUser from '../components/HeaderUser.vue'
+import { supabase } from '../supabase'
+
+export default {
+  name: 'Permissoes',
+  components: { Sidebar, HeaderUser },
+  data() {
+    return {
+      sidebarOpen: window.innerWidth >= 768,
+      users: [],
+      permissions: [],
+      form: { profileId: '', screen: '', canView: true },
+      userId: null
+    }
+  },
+  methods: {
+    async fetchUsers() {
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('company_id')
+        .eq('id', this.userId)
+        .single()
+      if (profile) {
+        const { data } = await supabase
+          .from('profiles')
+          .select('id, email')
+          .eq('company_id', profile.company_id)
+        this.users = data || []
+      }
+    },
+    async fetchPermissions() {
+      const { data } = await supabase.from('screen_permissions').select('*')
+      this.permissions = data || []
+    },
+    async addPermission() {
+      if (!this.form.profileId || !this.form.screen) return
+      await supabase.from('screen_permissions').insert({
+        profile_id: this.form.profileId,
+        screen: this.form.screen,
+        can_view: this.form.canView
+      })
+      this.form = { profileId: '', screen: '', canView: true }
+      await this.fetchPermissions()
+    },
+    getUserEmail(id) {
+      const u = this.users.find(x => x.id === id)
+      return u ? u.email : id
+    }
+  },
+  async mounted() {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      this.$router.push('/login')
+      return
+    }
+    this.userId = user.id
+    await this.fetchUsers()
+    await this.fetchPermissions()
+  }
+}
+</script>

--- a/src/views/Signup.vue
+++ b/src/views/Signup.vue
@@ -89,7 +89,8 @@ export default {
 
             await supabase.from('profiles').insert({
               id: data.user.id,
-              company_id: companyId
+              company_id: companyId,
+              role: 'admin'
             })
             alert('Cadastro realizado!')
           } else {

--- a/src/views/Usuarios.vue
+++ b/src/views/Usuarios.vue
@@ -45,6 +45,7 @@
               <tr>
                 <th class="px-4 py-2 font-medium text-gray-700">ID</th>
                 <th class="px-4 py-2 font-medium text-gray-700">E-mail</th>
+                <th class="px-4 py-2 font-medium text-gray-700">Perfil</th>
                 <th class="px-4 py-2"></th>
               </tr>
             </thead>
@@ -52,12 +53,13 @@
               <tr v-for="u in filteredUsers" :key="u.id" class="border-b last:border-b-0">
                 <td class="px-4 py-2">{{ u.id }}</td>
                 <td class="px-4 py-2">{{ u.email }}</td>
+                <td class="px-4 py-2">{{ u.role }}</td>
                 <td class="px-4 py-2 text-right">
                   <button @click="openUserModal(u, 'view')" class="btn btn-sm">Visualizar</button>
                 </td>
               </tr>
               <tr v-if="filteredUsers.length === 0">
-                <td colspan="3" class="px-4 py-6 text-center text-gray-500">Nenhum usuário encontrado</td>
+                <td colspan="4" class="px-4 py-6 text-center text-gray-500">Nenhum usuário encontrado</td>
               </tr>
             </tbody>
           </table>
@@ -75,6 +77,10 @@
           <div>
             <label class="block text-sm font-medium text-gray-700">Senha</label>
             <input type="password" v-model="userForm.password" :disabled="isUserView" class="w-full mt-1 px-4 py-2 border rounded-md" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Perfil</label>
+            <input type="text" v-model="userForm.role" disabled class="w-full mt-1 px-4 py-2 border rounded-md" />
           </div>
           <div class="flex justify-end space-x-2">
             <button type="button" @click="handleUserClose" class="px-4 py-2 rounded border">Fechar</button>
@@ -112,7 +118,7 @@ export default {
       showUserModal: false,
       userModalMode: 'new',
       selectedUserId: null,
-      userForm: { email: '', password: '' }
+      userForm: { email: '', password: '', role: 'user' }
     }
   },
   methods: {
@@ -179,7 +185,8 @@ export default {
             id: signUpData.user.id,
             email: signUpData.user.email,
             company_id: profileData.company_id,
-            onboarding_complete: true
+            onboarding_complete: true,
+            role: 'user'
           }
           for (const field of sharedFields) {
             if (field !== 'company_id' && profileData[field] !== undefined) {
@@ -197,10 +204,10 @@ export default {
       this.userModalMode = mode
       if (user) {
         this.selectedUserId = user.id
-        this.userForm = { email: user.email, password: '' }
+        this.userForm = { email: user.email, password: '', role: user.role }
       } else {
         this.selectedUserId = null
-        this.userForm = { email: '', password: '' }
+        this.userForm = { email: '', password: '', role: 'user' }
       }
       this.showUserModal = true
     },
@@ -217,7 +224,7 @@ export default {
       this.showUserModal = false
       this.userModalMode = 'new'
       this.selectedUserId = null
-      this.userForm = { email: '', password: '' }
+      this.userForm = { email: '', password: '', role: 'user' }
     },
     enableUserEdit() {
       this.userModalMode = 'edit'
@@ -254,9 +261,9 @@ export default {
         .single()
 
       if (profile) {
-        let query = supabase
-          .from('profiles')
-          .select('id, email')
+      let query = supabase
+        .from('profiles')
+        .select('id, email, role')
 
         if (profile.company_id === null) {
           query = query.is('company_id', null)

--- a/src/views/__tests__/Permissoes.test.ts
+++ b/src/views/__tests__/Permissoes.test.ts
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/vue'
+import { describe, it, expect, vi } from 'vitest'
+import Permissoes from '../Permissoes.vue'
+
+vi.mock('../../supabase', () => ({
+  supabase: {
+    from: () => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: {}, error: null }),
+      insert: vi.fn().mockResolvedValue({ data: {}, error: null })
+    }),
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: '1' } } }) }
+  }
+}))
+
+describe('Permissoes view', () => {
+  it('renders screen field', () => {
+    const { getByLabelText } = render(Permissoes, { global: { stubs: ['router-link'] } })
+    expect(getByLabelText('Tela')).toBeTruthy()
+  })
+})

--- a/supabase/schemas/039_add_role_to_profiles.sql
+++ b/supabase/schemas/039_add_role_to_profiles.sql
@@ -1,0 +1,2 @@
+alter table profiles add column if not exists role text not null default 'user';
+create unique index if not exists unique_admin_per_company on profiles(company_id) where role = 'admin';

--- a/supabase/schemas/040_create_screen_permissions.sql
+++ b/supabase/schemas/040_create_screen_permissions.sql
@@ -1,0 +1,21 @@
+create table if not exists screen_permissions (
+  id uuid primary key default uuid_generate_v4(),
+  profile_id uuid references profiles(id) on delete cascade,
+  screen text not null,
+  can_view boolean default true,
+  created_at timestamp with time zone default now()
+);
+
+alter table screen_permissions enable row level security;
+
+create policy "Owner can manage own permissions" on screen_permissions
+  for all using (auth.uid() = profile_id);
+
+create policy "Company admin can manage screen permissions" on screen_permissions
+  for all using (
+    exists (
+      select 1 from profiles p_admin
+      join profiles p_user on p_admin.company_id = p_user.company_id
+      where p_admin.id = auth.uid() and p_admin.role = 'admin' and p_user.id = screen_permissions.profile_id
+    )
+  );


### PR DESCRIPTION
## Summary
- add role to profiles and ensure single admin per company
- create screen_permissions table with policies
- add permissions management view and route
- show user role in user listing and modal
- update signup to assign admin role
- add sidebar link for permissions
- test rendering of permissions screen

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616ab0a1dc8320b9b0e23b71e4c560