### PR TITLE
Restrict regular users from permissions page

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -143,7 +143,11 @@
               </svg>
               <span>Usuários</span>
             </router-link>
-            <router-link to="/permissoes" class="flex items-center text-gray-700 hover:text-primary">
+            <router-link
+              v-if="userRole !== 'user'"
+              to="/permissoes"
+              class="flex items-center text-gray-700 hover:text-primary"
+            >
               <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
               </svg>
@@ -164,12 +168,30 @@
 </template>
   
 <script>
+import { supabase } from '../supabase'
+
 export default {
   name: 'Sidebar',
   props: {
     isOpen: {
       type: Boolean,
       default: true
+    }
+  },
+  data() {
+    return {
+      userRole: null
+    }
+  },
+  async mounted() {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (user) {
+      const { data } = await supabase
+        .from('profiles')
+        .select('role')
+        .eq('id', user.id)
+        .single()
+      this.userRole = data ? data.role : null
     }
   }
 }

--- a/src/components/__tests__/Sidebar.test.ts
+++ b/src/components/__tests__/Sidebar.test.ts
@@ -6,7 +6,11 @@ import Sidebar from '../Sidebar.vue'
 
 vi.mock('../../supabase', () => ({
   supabase: {
-    from: () => ({ select: vi.fn().mockResolvedValue({ data: [], error: null }) }),
+    from: () => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { role: 'admin' }, error: null })
+    }),
     auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: '1' } } }), signOut: vi.fn() }
   }
 }))

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -83,9 +83,14 @@ router.beforeEach(async (to, from, next) => {
   if (user) {
     const { data } = await supabase
       .from('profiles')
-      .select('onboarding_complete, company_id')
+      .select('onboarding_complete, company_id, role')
       .eq('id', user.id)
       .single()
+
+    if (to.path === '/permissoes' && data?.role === 'user') {
+      next('/dashboard')
+      return
+    }
 
     if (data && !data.onboarding_complete) {
       if (data.company_id) {

--- a/src/views/Permissoes.vue
+++ b/src/views/Permissoes.vue
@@ -121,6 +121,17 @@ export default {
       this.$router.push('/login')
       return
     }
+    const { data } = await supabase
+      .from('profiles')
+      .select('id, role')
+      .eq('id', user.id)
+      .single()
+
+    if (data?.role === 'user') {
+      this.$router.push('/dashboard')
+      return
+    }
+
     this.userId = user.id
     await this.fetchUsers()
     await this.fetchPermissions()


### PR DESCRIPTION
## Summary
- hide "Permissões" link for non-admin users
- check user role before entering the Permissões route
- block access to "/permissoes" via router guard
- adjust Sidebar tests for new supabase calls

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616e7579c48320b31ef0469570aef9