### PR TITLE
Add screen list to permission view

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -36,7 +36,7 @@ import Permissoes from '../views/Permissoes.vue'
 import { supabase } from '../supabase'
 
 
-const routes = [
+export const routes = [
   { path: '/', name: 'Home', component: Home },
   { path: '/cadastro', name: 'Signup', component: Signup },
   { path: '/confirmacao', name: 'Confirmacao', component: Confirmacao },
@@ -108,5 +108,7 @@ router.afterEach((to) => {
     window.gtag('config', 'G-8DZT2EVSC7', { page_path: to.fullPath })
   }
 })
+
+export const screenNames = routes.map(r => r.name)
 
 export default router

--- a/src/views/Permissoes.vue
+++ b/src/views/Permissoes.vue
@@ -22,7 +22,10 @@
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700" for="screen">Tela</label>
-            <input id="screen" type="text" v-model="form.screen" class="w-full mt-1 px-4 py-2 border rounded-md" />
+            <select id="screen" v-model="form.screen" class="w-full mt-1 px-4 py-2 border rounded-md">
+              <option value="" disabled>Selecione</option>
+              <option v-for="s in screens" :key="s" :value="s">{{ s }}</option>
+            </select>
           </div>
           <div class="flex items-center">
             <input type="checkbox" v-model="form.canView" id="canView" class="mr-2" />
@@ -68,6 +71,7 @@
 import Sidebar from '../components/Sidebar.vue'
 import HeaderUser from '../components/HeaderUser.vue'
 import { supabase } from '../supabase'
+import { screenNames } from '../router'
 
 export default {
   name: 'Permissoes',
@@ -77,6 +81,7 @@ export default {
       sidebarOpen: window.innerWidth >= 768,
       users: [],
       permissions: [],
+      screens: screenNames,
       form: { profileId: '', screen: '', canView: true },
       userId: null
     }


### PR DESCRIPTION
## Summary
- export `routes` and `screenNames` from the router
- allow selecting existing screens in `Permissoes.vue`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616d3bcda08320be0f32b980bdb01e