### PR TITLE
Limit client permission list

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -115,5 +115,23 @@ router.afterEach((to) => {
 })
 
 export const screenNames = routes.map(r => r.name)
+export const loggedScreenNames = routes
+  .filter(r => ![
+    'Home',
+    'Signup',
+    'Login',
+    'Confirmacao',
+    'LinkExpirado',
+    'SearchProfiles',
+    'PublicPage',
+    'Planos',
+    'Contato',
+    'Faq',
+    'PoliticaDePrivacidade',
+    'TermosDeUso',
+    'PagamentoPlus',
+    'PagamentoAgendamento'
+  ].includes(r.name))
+  .map(r => r.name)
 
 export default router

--- a/src/views/Permissoes.vue
+++ b/src/views/Permissoes.vue
@@ -71,7 +71,7 @@
 import Sidebar from '../components/Sidebar.vue'
 import HeaderUser from '../components/HeaderUser.vue'
 import { supabase } from '../supabase'
-import { screenNames } from '../router'
+import { loggedScreenNames } from '../router'
 
 export default {
   name: 'Permissoes',
@@ -81,7 +81,7 @@ export default {
       sidebarOpen: window.innerWidth >= 768,
       users: [],
       permissions: [],
-      screens: screenNames,
+      screens: loggedScreenNames,
       form: { profileId: '', screen: '', canView: true },
       userId: null
     }


### PR DESCRIPTION
## Summary
- expose logged-in screen list
- show only logged screens in Permissions view

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617025b914832084c70713c2c31e42