### PR TITLE
Fix duplicate permission entries

### DIFF
--- a/src/views/Permissoes.vue
+++ b/src/views/Permissoes.vue
@@ -116,7 +116,9 @@ export default {
         screen,
         can_view: this.form.canView
       }))
-      await supabase.from('screen_permissions').insert(inserts)
+      await supabase
+        .from('screen_permissions')
+        .upsert(inserts, { onConflict: ['profile_id', 'screen'] })
       this.form = { profileId: '', screens: [], canView: true }
       await this.fetchPermissions()
     },

--- a/supabase/schemas/041_unique_screen_permissions.sql
+++ b/supabase/schemas/041_unique_screen_permissions.sql
@@ -1,0 +1,1 @@
+create unique index if not exists unique_screen_permission on screen_permissions(profile_id, screen);


### PR DESCRIPTION
## Summary
- prevent duplicate permission rows in screen_permissions
- update permissions page to upsert entries

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686182289a0c8320b6b4e4a96e9ad9e0