### PR TITLE
Fix Sidebar test for duplicated brand text

### DIFF
--- a/src/components/__tests__/Sidebar.test.ts
+++ b/src/components/__tests__/Sidebar.test.ts
@@ -43,8 +43,11 @@ describe('Sidebar', () => {
 
   it('hides section when no access', async () => {
     role = 'user'
-    const { findByText, queryByText } = render(Sidebar, { props: { isOpen: true }, global: { stubs: ['router-link'] } })
-    await findByText('Agenda Zen')
+    const { findAllByText, queryByText } = render(Sidebar, {
+      props: { isOpen: true },
+      global: { stubs: ['router-link'] }
+    })
+    await findAllByText('Agenda Zen')
     expect(queryByText('Cadastros')).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- update Sidebar test to use `findAllByText` so the test passes even when multiple `Agenda Zen` instances are present

## Testing
- `npm test -- -t Sidebar --run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861838b3bc483209460155711b4c693