### PR TITLE
Fix sidebar test

### DIFF
--- a/src/components/__tests__/Sidebar.test.ts
+++ b/src/components/__tests__/Sidebar.test.ts
@@ -43,11 +43,11 @@ describe('Sidebar', () => {
 
   it('hides section when no access', async () => {
     role = 'user'
-    const { findAllByText, queryByText } = render(Sidebar, {
+    const { findAllByText, queryAllByText } = render(Sidebar, {
       props: { isOpen: true },
       global: { stubs: ['router-link'] }
     })
     await findAllByText('Agenda Zen')
-    expect(queryByText('Cadastros')).toBeNull()
+    expect(queryAllByText('Cadastros')).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## Summary
- tweak Sidebar test to avoid `queryByText` error when multiple nodes exist

## Testing
- `npm test -- -t Sidebar` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861859c2bbc8320bf33a174eb4f9655