### PR TITLE
Fix sidebar access test

### DIFF
--- a/src/components/__tests__/Sidebar.test.ts
+++ b/src/components/__tests__/Sidebar.test.ts
@@ -13,7 +13,9 @@ vi.mock('../../supabase', () => ({
         return {
           select: vi.fn().mockReturnThis(),
           eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: { role }, error: null })
+          single: vi.fn().mockImplementation(() =>
+            Promise.resolve({ data: { role }, error: null })
+          )
         }
       }
       if (table === 'screen_permissions') {


### PR DESCRIPTION
## Summary
- update Sidebar unit test to use dynamic mock for user role

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686187aa32a08320be170af0fa8c5bdb