### PR TITLE
Fix sidebar access checks

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -187,6 +187,7 @@ export default {
   },
   methods: {
     canSee(name) {
+      if (this.userRole === null) return false
       if (this.userRole !== 'user') return true
       return this.allowedScreens.includes(name)
     },


### PR DESCRIPTION
## Summary
- ensure sections stay hidden while user role is loading

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861bffca38883209ce44354f05d587b