### PR TITLE
Fix Sidebar test isolation

### DIFF
--- a/src/components/__tests__/Sidebar.test.ts
+++ b/src/components/__tests__/Sidebar.test.ts
@@ -45,6 +45,7 @@ describe('Sidebar', () => {
 
   it('hides section when no access', async () => {
     role = 'user'
+    vi.resetModules()
     const Sidebar = (await import('../Sidebar.vue')).default
     const { findAllByText, queryAllByText } = render(Sidebar, {
       props: { isOpen: true },


### PR DESCRIPTION
## Summary
- reload Vue component between tests to ensure mocks receive updated role values

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c1ee839c832099e5e83410daad70