### PR TITLE
Fix missing filters in reports

### DIFF
--- a/src/views/Faturamento.vue
+++ b/src/views/Faturamento.vue
@@ -13,11 +13,11 @@
 
       <section class="bg-white p-4 rounded-lg shadow space-y-4">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-4 items-start">
-          <div v-if="canSeeServices">
+          <div>
             <label class="block text-sm font-medium text-gray-700">Serviços</label>
             <div class="mt-1 space-y-1">
               <label v-for="s in services" :key="s.id" class="flex items-center space-x-2">
-                <input type="checkbox" :value="s.id" v-model="selectedServices" />
+                <input type="checkbox" :value="s.id" v-model="selectedServices" :disabled="!canSeeServices" />
                 <span>{{ s.name }}</span>
               </label>
             </div>
@@ -104,18 +104,13 @@ export default {
   },
   methods: {
     async fetchServices() {
-      if (!this.canSeeServices) {
-        this.services = []
-        this.selectedServices = []
-        return
-      }
       const { data } = await supabase
         .from('services')
         .select()
         .eq('user_id', this.userId)
         .eq('active', true)
       this.services = data || []
-      this.selectedServices = this.services.map(s => s.id)
+      this.selectedServices = this.canSeeServices ? this.services.map(s => s.id) : []
     },
     async fetchRevenue() {
       if (!this.filterStart || !this.filterEnd) return

--- a/src/views/Recebimento.vue
+++ b/src/views/Recebimento.vue
@@ -13,16 +13,16 @@
 
       <section class="bg-white p-4 rounded-lg shadow space-y-4">
         <div class="grid grid-cols-1 md:grid-cols-6 gap-4 items-end">
-          <div v-if="canSeeClients">
+          <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Cliente</label>
-            <select v-model="clientId" class="w-full px-4 py-2 border rounded-md">
+            <select v-model="clientId" class="w-full px-4 py-2 border rounded-md" :disabled="!canSeeClients">
               <option value="">Todos</option>
               <option v-for="c in clients" :key="c.id" :value="c.id">{{ c.name }}</option>
             </select>
           </div>
-          <div v-if="canSeeServices">
+          <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Serviço</label>
-            <select v-model="serviceId" class="w-full px-4 py-2 border rounded-md">
+            <select v-model="serviceId" class="w-full px-4 py-2 border rounded-md" :disabled="!canSeeServices">
               <option value="">Todos</option>
               <option v-for="s in services" :key="s.id" :value="s.id">{{ s.name }}</option>
             </select>

--- a/src/views/RelatorioAgendamentos.vue
+++ b/src/views/RelatorioAgendamentos.vue
@@ -22,14 +22,14 @@
             <input type="date" v-model="filterStart" class="border px-3 py-2 rounded" />
             <input type="date" v-model="filterEnd" class="border px-3 py-2 rounded" />
           </div>
-          <div v-if="canSeeClients">
-            <select v-model="clientId" class="border px-3 py-2 rounded">
+          <div>
+            <select v-model="clientId" class="border px-3 py-2 rounded" :disabled="!canSeeClients">
               <option value="">Todos os clientes</option>
               <option v-for="c in clients" :key="c.id" :value="c.id">{{ c.name }}</option>
             </select>
           </div>
-          <div v-if="canSeeServices">
-            <select v-model="serviceId" class="border px-3 py-2 rounded">
+          <div>
+            <select v-model="serviceId" class="border px-3 py-2 rounded" :disabled="!canSeeServices">
               <option value="">Todos os serviços</option>
               <option v-for="s in services" :key="s.id" :value="s.id">{{ s.name }}</option>
             </select>

--- a/src/views/RelatorioEmAberto.vue
+++ b/src/views/RelatorioEmAberto.vue
@@ -13,14 +13,14 @@
 
       <section class="bg-white p-4 rounded-lg shadow space-y-4">
         <div class="flex flex-col md:flex-row md:items-end md:space-x-4 space-y-4 md:space-y-0">
-          <div v-if="canSeeClients">
-            <select v-model="clientId" class="border px-3 py-2 rounded">
+          <div>
+            <select v-model="clientId" class="border px-3 py-2 rounded" :disabled="!canSeeClients">
               <option value="">Todos os clientes</option>
               <option v-for="c in clients" :key="c.id" :value="c.id">{{ c.name }}</option>
             </select>
           </div>
-          <div v-if="canSeeServices">
-            <select v-model="serviceId" class="border px-3 py-2 rounded">
+          <div>
+            <select v-model="serviceId" class="border px-3 py-2 rounded" :disabled="!canSeeServices">
               <option value="">Todos os serviços</option>
               <option v-for="s in services" :key="s.id" :value="s.id">{{ s.name }}</option>
             </select>


### PR DESCRIPTION
## Summary
- always display client and service filters even if permission check fails
- remove early return from `fetchServices`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c1a3e1688320a7a8f103f2cf385a