### PR TITLE
Fix Sidebar access test

### DIFF
--- a/src/components/__tests__/Sidebar.test.ts
+++ b/src/components/__tests__/Sidebar.test.ts
@@ -47,13 +47,13 @@ describe('Sidebar', () => {
     role = 'user'
     vi.resetModules()
     const Sidebar = (await import('../Sidebar.vue')).default
-    const { findAllByText, queryAllByText } = render(Sidebar, {
+    const { findAllByText, queryByText } = render(Sidebar, {
       props: { isOpen: true },
       global: { stubs: ['router-link'] }
     })
     await findAllByText('Agenda Zen')
     await waitFor(() => {
-      expect(queryAllByText('Cadastros')).toHaveLength(0)
+      expect(queryByText('Cadastros')).toBeNull()
     })
   })
 })


### PR DESCRIPTION
## Summary
- adjust Sidebar test to use `queryByText`

## Testing
- `npm test -- -t Sidebar -i` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c364b1348320baac05f4a4e49653