### PR TITLE
Fix Sidebar test mocking

### DIFF
--- a/src/components/__tests__/Sidebar.test.ts
+++ b/src/components/__tests__/Sidebar.test.ts
@@ -32,7 +32,7 @@ vi.mock('../../supabase', () => ({
   }
 }))
 
-vi.mock('../../router/index.js', () => ({
+vi.mock('../../router', () => ({
   loggedScreenNames: []
 }))
 


### PR DESCRIPTION
## Summary
- correct router mock path in `Sidebar.test.ts`

## Testing
- `npx vitest run src/components/__tests__/Sidebar.test.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6861c67e826083208b71e6f29901fd59