### PR TITLE
Adjust filters layout in scheduling report

### DIFF
--- a/src/views/RelatorioAgendamentos.vue
+++ b/src/views/RelatorioAgendamentos.vue
@@ -12,24 +12,24 @@
       <HeaderUser title="Relatório de Agendamentos" />
 
       <section class="bg-white p-4 rounded-lg shadow space-y-4">
-        <div class="flex flex-wrap items-end gap-4">
+        <div class="flex flex-col md:flex-row md:items-end md:space-x-4 space-y-4 md:space-y-0">
           <div class="flex flex-wrap gap-2">
             <button class="btn btn-sm" @click="setPeriodo('dia')">Dia</button>
             <button class="btn btn-sm" @click="setPeriodo('semana')">Semana</button>
             <button class="btn btn-sm" @click="setPeriodo('mes')">Mês</button>
           </div>
           <div class="flex space-x-2">
-            <input type="date" v-model="filterStart" class="w-full border px-3 py-2 rounded" />
-            <input type="date" v-model="filterEnd" class="w-full border px-3 py-2 rounded" />
+            <input type="date" v-model="filterStart" class="border px-3 py-2 rounded" />
+            <input type="date" v-model="filterEnd" class="border px-3 py-2 rounded" />
           </div>
           <div>
-            <select v-model="clientId" class="w-full border px-3 py-2 rounded" :disabled="!canSeeClients">
+            <select v-model="clientId" class="border px-3 py-2 rounded" :disabled="!canSeeClients">
               <option value="">Todos os clientes</option>
               <option v-for="c in clients" :key="c.id" :value="c.id">{{ c.name }}</option>
             </select>
           </div>
           <div>
-            <select v-model="serviceId" class="w-full border px-3 py-2 rounded" :disabled="!canSeeServices">
+            <select v-model="serviceId" class="border px-3 py-2 rounded" :disabled="!canSeeServices">
               <option value="">Todos os serviços</option>
               <option v-for="s in services" :key="s.id" :value="s.id">{{ s.name }}</option>
             </select>


### PR DESCRIPTION
## Summary
- keep all filters on a single row in RelatorioAgendamentos

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861d3263c1c8320bd55884f0ee77c89