### PR TITLE
UI refinements for AgendaZen landing pages

### DIFF
--- a/public/icons/hairdresser.svg
+++ b/public/icons/hairdresser.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#6d28d9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="5" cy="6" r="3" />
+  <circle cx="19" cy="6" r="3" />
+  <path d="M8 21l8-13" />
+  <path d="M8 8l8 13" />
+</svg>

--- a/public/icons/manicure.svg
+++ b/public/icons/manicure.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#6d28d9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 2l1.5 4.5L18 8l-4.5 1.5L12 14l-1.5-4.5L6 8l4.5-1.5L12 2z" />
+</svg>

--- a/public/icons/psychology.svg
+++ b/public/icons/psychology.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#6d28d9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 12a4 4 0 1 0-4-4 4 4 0 0 0 4 4z" />
+  <path d="M6 20v-2a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v2" />
+</svg>

--- a/public/icons/therapy.svg
+++ b/public/icons/therapy.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#6d28d9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10" />
+  <path d="M12 8v8M8 12h8" />
+</svg>

--- a/src/components/AudienceSection.vue
+++ b/src/components/AudienceSection.vue
@@ -3,8 +3,12 @@
     <div class="container mx-auto text-center">
       <h2 class="text-3xl font-bold mb-12">Para quem é</h2>
       <div class="max-w-5xl mx-auto grid gap-8 md:grid-cols-4">
-        <div v-for="a in audience" :key="a.title" class="space-y-3">
-          <div class="text-4xl">{{ a.icon }}</div>
+        <div
+          v-for="a in audience"
+          :key="a.title"
+          class="space-y-3 p-6 bg-white rounded-lg shadow-sm transition hover:shadow-md"
+        >
+          <img :src="a.icon" alt="" class="w-10 h-10 mx-auto text-primary" />
           <h3 class="font-semibold">{{ a.title }}</h3>
           <p class="text-sm text-gray-600">{{ a.desc }}</p>
         </div>
@@ -19,10 +23,10 @@ export default {
   data() {
     return {
       audience: [
-        { icon: '🧑‍⚕️', title: 'Fisioterapeutas', desc: 'Organize sessões e pagamentos facilmente.' },
-        { icon: '🧠', title: 'Psicólogos', desc: 'Gerencie consultas e lembretes automáticos.' },
-        { icon: '💇‍♀️', title: 'Cabeleireiros', desc: 'Agendamentos rápidos pelo celular.' },
-        { icon: '💅', title: 'Manicure', desc: 'Confirmações pelo WhatsApp em segundos.' }
+        { icon: '/icons/therapy.svg', title: 'Fisioterapeutas', desc: 'Organize sessões e pagamentos facilmente.' },
+        { icon: '/icons/psychology.svg', title: 'Psicólogos', desc: 'Gerencie consultas e lembretes automáticos.' },
+        { icon: '/icons/hairdresser.svg', title: 'Cabeleireiros', desc: 'Agendamentos rápidos pelo celular.' },
+        { icon: '/icons/manicure.svg', title: 'Manicure', desc: 'Confirmações pelo WhatsApp em segundos.' }
       ]
     }
   }

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,26 +1,32 @@
 <template>
-  <footer class="bg-gray-100 text-center text-sm text-gray-500 py-6 space-y-4 border-t">
-    <div class="container mx-auto space-y-4">
-    <div class="space-x-4 text-primary">
-      <a href="https://www.instagram.com/agendazen_" target="_blank" class="hover:underline">Instagram</a>
-      <a href="https://www.facebook.com/agenda.zen" target="_blank" class="hover:underline">Facebook</a>
-      <a href="https://x.com/agenda_zen" target="_blank" class="hover:underline">X</a>
-      <a href="https://wa.me/5531999999999" target="_blank" class="hover:underline inline-flex items-center">
-        <img src="/icons/whatsapp.svg" alt="WhatsApp" class="w-4 h-4 mr-1" />WhatsApp
-      </a>
-    </div>
-    <div class="flex flex-wrap justify-center space-x-2">
-      <router-link to="/termos-de-uso" class="hover:underline">Termos de uso</router-link>
-      <span>|</span>
-      <router-link to="/planos" class="hover:underline">Planos</router-link>
-      <span>|</span>
-      <router-link to="/contato" class="hover:underline">Contato</router-link>
-      <span>|</span>
-      <router-link to="/faq" class="hover:underline">FAQ</router-link>
-      <span>|</span>
-      <router-link to="/politica-de-privacidade" class="hover:underline">Política de privacidade</router-link>
-    </div>
-    <p>© {{ new Date().getFullYear() }} Agenda Zen — Todos os direitos reservados</p>
+  <footer class="bg-gray-100 text-sm text-gray-600 border-t">
+    <div class="container mx-auto px-8 py-10 grid gap-8 md:grid-cols-4">
+      <div>
+        <router-link to="/" class="text-xl font-semibold text-primary-dark block mb-2">Agenda Zen</router-link>
+        <p class="text-xs">Desenvolvido com ❤️ no Brasil</p>
+      </div>
+      <div>
+        <h3 class="font-semibold mb-2">Links</h3>
+        <router-link to="/planos" class="block hover:underline">Planos</router-link>
+        <router-link to="/faq" class="block hover:underline">FAQ</router-link>
+        <router-link to="/contato" class="block hover:underline">Contato</router-link>
+      </div>
+      <div>
+        <h3 class="font-semibold mb-2">Legal</h3>
+        <router-link to="/termos-de-uso" class="block hover:underline">Termos de uso</router-link>
+        <router-link to="/politica-de-privacidade" class="block hover:underline">Privacidade</router-link>
+      </div>
+      <div>
+        <h3 class="font-semibold mb-2">Redes</h3>
+        <div class="space-y-1">
+          <a href="https://www.instagram.com/agendazen_" target="_blank" class="block hover:underline">Instagram</a>
+          <a href="https://www.facebook.com/agenda.zen" target="_blank" class="block hover:underline">Facebook</a>
+          <a href="https://x.com/agenda_zen" target="_blank" class="block hover:underline">X</a>
+          <a href="https://wa.me/5531999999999" target="_blank" class="block hover:underline inline-flex items-center">
+            <img src="/icons/whatsapp.svg" alt="WhatsApp" class="w-4 h-4 mr-1" />WhatsApp
+          </a>
+        </div>
+      </div>
     </div>
   </footer>
 </template>

--- a/src/components/TestimonialsSection.vue
+++ b/src/components/TestimonialsSection.vue
@@ -1,11 +1,18 @@
 <template>
-  <section class="py-20 px-8">
+  <section class="py-20 px-8 bg-gray-50">
     <div class="container mx-auto text-center">
       <h2 class="text-3xl font-bold mb-12">O que dizem nossos clientes</h2>
       <div class="max-w-5xl mx-auto grid gap-8 md:grid-cols-3">
-        <div v-for="t in testimonials" :key="t.name" class="bg-white p-6 rounded-lg shadow">
-          <img :src="t.photo" alt="Foto de {{ t.name }}" class="w-16 h-16 mx-auto rounded-full mb-4" />
-          <p class="italic mb-2">{{ t.text }}</p>
+        <div
+          v-for="t in testimonials"
+          :key="t.name"
+          class="bg-white p-6 rounded-lg shadow flex flex-col items-center text-center"
+        >
+          <svg class="w-6 h-6 text-primary mb-2" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M7.17 6.17A5 5 0 0 0 4 10v4a2 2 0 0 0 2 2h2a2 2 0 0 0 2-2v-2a2 2 0 0 0-2-2H6v-1a3 3 0 0 1 3-3zM15.17 6.17A5 5 0 0 0 12 10v4a2 2 0 0 0 2 2h2a2 2 0 0 0 2-2v-2a2 2 0 0 0-2-2h-2v-1a3 3 0 0 1 3-3z" />
+          </svg>
+          <img :src="t.photo" alt="Foto de {{ t.name }}" class="w-16 h-16 rounded-full mb-4" />
+          <p class="italic mb-2 text-gray-700">{{ t.text }}</p>
           <p class="font-semibold text-primary">{{ t.name }}</p>
           <p class="text-sm text-gray-500">{{ t.role }}</p>
         </div>
@@ -20,9 +27,9 @@ export default {
   data() {
     return {
       testimonials: [
-        { photo: 'https://via.placeholder.com/80', text: 'O AgendaZen facilitou totalmente meus atendimentos.', name: 'Ana Lima', role: 'Fisioterapeuta' },
-        { photo: 'https://via.placeholder.com/80', text: 'Uso todos os dias e recomendo para meus colegas.', name: 'Carlos Souza', role: 'Psicólogo' },
-        { photo: 'https://via.placeholder.com/80', text: 'Meus clientes adoram receber lembretes automáticos.', name: 'Mariana Alves', role: 'Manicure' }
+        { photo: 'https://source.unsplash.com/80x80/?woman,1', text: 'O AgendaZen facilitou totalmente meus atendimentos.', name: 'Ana Lima', role: 'Fisioterapeuta' },
+        { photo: 'https://source.unsplash.com/80x80/?man,2', text: 'Uso todos os dias e recomendo para meus colegas.', name: 'Carlos Souza', role: 'Psicólogo' },
+        { photo: 'https://source.unsplash.com/80x80/?woman,3', text: 'Meus clientes adoram receber lembretes automáticos.', name: 'Mariana Alves', role: 'Manicure' }
       ]
     }
   }

--- a/src/views/Confirmacao.vue
+++ b/src/views/Confirmacao.vue
@@ -1,7 +1,7 @@
 <template>
   <Navbar />
-  <section class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-blue-100 px-4">
-    <div class="bg-white p-10 rounded-2xl shadow-xl w-full max-w-lg text-center space-y-6">
+  <section class="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary/10 to-white px-4">
+    <div class="bg-white p-6 md:p-10 rounded-2xl shadow-xl w-full max-w-lg text-center space-y-6">
       <img src="/icons/check.svg" alt="Sucesso" class="w-16 h-16 mx-auto text-green-500" />
       <h1 class="text-2xl font-bold text-green-600">Cadastro efetuado com sucesso</h1>
       <div class="flex justify-center space-x-4">

--- a/src/views/Contato.vue
+++ b/src/views/Contato.vue
@@ -1,7 +1,7 @@
 <template>
   <Navbar />
   <section class="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary/5 to-primary/10 px-4">
-    <div class="bg-white p-10 rounded-2xl shadow-xl w-full max-w-lg">
+    <div class="bg-white p-6 md:p-10 rounded-2xl shadow-xl w-full max-w-lg">
       <div class="mb-8 text-center">
         <h2 class="text-3xl font-extrabold text-primary-dark">Fale conosco</h2>
         <p class="text-gray-500">Envie sua mensagem e entraremos em contato</p>

--- a/src/views/LinkExpirado.vue
+++ b/src/views/LinkExpirado.vue
@@ -1,7 +1,7 @@
 <template>
   <Navbar />
-  <section class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-blue-100 px-4">
-    <div class="bg-white p-10 rounded-2xl shadow-xl w-full max-w-lg text-center space-y-6">
+  <section class="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary/10 to-white px-4">
+    <div class="bg-white p-6 md:p-10 rounded-2xl shadow-xl w-full max-w-lg text-center space-y-6">
       <img src="/icons/error.svg" alt="Erro" class="w-16 h-16 mx-auto text-red-500" />
       <h1 class="text-2xl font-bold text-red-600">Link expirado ou inválido</h1>
       <p class="text-gray-700">Informe seu e-mail para receber um novo link de confirmação.</p>

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,7 +1,7 @@
 <template>
     <Navbar />
-    <section class="min-h-screen flex items-center justify-center bg-gradient-to-br from-indigo-50 to-white px-4">
-      <div class="bg-white p-10 rounded-2xl shadow-xl w-full max-w-lg">
+    <section class="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary/10 to-white px-4">
+      <div class="bg-white p-6 md:p-10 rounded-2xl shadow-xl w-full max-w-lg">
         <div class="mb-8 text-center">
           <h2 class="text-3xl font-extrabold text-primary">Entrar</h2>
           <p class="text-gray-500">Acesse sua conta do Agenda Zen</p>

--- a/src/views/Signup.vue
+++ b/src/views/Signup.vue
@@ -1,9 +1,9 @@
 <template>
   <Navbar />
-  <section class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-blue-100 px-4">
-    <div class="bg-white p-10 rounded-2xl shadow-xl w-full max-w-lg">
+  <section class="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary/10 to-white px-4">
+    <div class="bg-white p-6 md:p-10 rounded-2xl shadow-xl w-full max-w-lg">
       <div class="mb-8 text-center">
-        <h2 class="text-3xl font-extrabold text-blue-700">Crie sua conta</h2>
+        <h2 class="text-3xl font-extrabold text-primary-dark">Crie sua conta</h2>
         <p class="text-gray-500">Comece agora a organizar seus atendimentos com praticidade</p>
       </div>
         <form @submit.prevent="handleSignup" class="space-y-5">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,12 +11,12 @@ export default {
       },
       colors: {
         primary: {
-          DEFAULT: '#6d28d9',
-          dark: '#5b21b6',
+          DEFAULT: '#8b5cf6',
+          dark: '#6d28d9',
         },
         secondary: {
-          DEFAULT: '#10b981',
-          dark: '#059669'
+          DEFAULT: '#64748b',
+          dark: '#475569'
         }
       },
     },


### PR DESCRIPTION
## Summary
- lighten brand palette and secondary colors
- update testimonials layout with quotes and unsplash photos
- replace emoji icons in "Para quem é" with vector icons
- tweak form spacing for small screens
- refine gradients and footer layout

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e7c2cd508320bffc270236599add