### PR TITLE
Improve hero banner gradient

### DIFF
--- a/src/components/HeroBanner.vue
+++ b/src/components/HeroBanner.vue
@@ -1,5 +1,5 @@
 <template>
-    <section class="bg-gradient-to-br from-white to-purple-50 py-16 md:py-24">
+    <section class="bg-gradient-to-r from-[#f7f5ff] to-[#e8e6fc] py-16 md:py-24">
       <div class="container max-w-6xl grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
         <div class="flex flex-col justify-center text-center md:text-left max-w-lg mx-auto md:mx-0">
           <h1 class="text-4xl md:text-5xl font-semibold text-gray-900 mb-4 md:mb-6">A sua agenda online que trabalha por você!</h1>
@@ -13,11 +13,11 @@
             </router-link>
           </div>
         </div>
-        <div class="flex justify-center md:justify-end">
+        <div class="flex justify-center md:justify-end md:pr-4 bg-transparent">
           <img
             src="/hero_illustration.png"
             alt="Profissional usando sistema de agendamento online"
-            class="max-w-[500px] w-full h-auto"
+            class="max-w-[500px] w-full h-auto rounded-none shadow-none"
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- tweak hero banner gradient to smoothly match the right side image
- ensure image section has transparent background and padding
- remove rounding/shadow from hero image

## Testing
- `npm run test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6861fd470c28832089daa2eefefffeb9